### PR TITLE
Fixing escape character warnings flagged by CI

### DIFF
--- a/pydough/types/array_type.py
+++ b/pydough/types/array_type.py
@@ -35,7 +35,7 @@ class ArrayType(PyDoughType):
         return f"array[{self.elem_type.json_string}]"
 
     # The string pattern that array types must adhere to.
-    type_string_pattern: re.Pattern = re.compile("array\[(.+)\]")
+    type_string_pattern: re.Pattern = re.compile(r"array\[(.+)\]")
 
     @staticmethod
     def parse_from_string(type_string: str) -> Optional[PyDoughType]:

--- a/pydough/types/decimal_type.py
+++ b/pydough/types/decimal_type.py
@@ -50,7 +50,7 @@ class DecimalType(PyDoughType):
         return f"decimal[{self.precision},{self.scale}]"
 
     # The string pattern that all decimal types must adhere to.
-    type_string_pattern: re.Pattern = re.compile("decimal\[(\d{1,2}),(\d{1,2})\]")
+    type_string_pattern: re.Pattern = re.compile(r"decimal\[(\d{1,2}),(\d{1,2})\]")
 
     @staticmethod
     def parse_from_string(type_string: str) -> Optional[PyDoughType]:

--- a/pydough/types/map_type.py
+++ b/pydough/types/map_type.py
@@ -48,7 +48,7 @@ class MapType(PyDoughType):
 
     # The string pattern that map types must adhere to. The delineation
     # between the key and value is handled later.
-    type_string_pattern: re.Pattern = re.compile("map\[(.+,.+)\]")
+    type_string_pattern: re.Pattern = re.compile(r"map\[(.+,.+)\]")
 
     @staticmethod
     def parse_from_string(type_string: str) -> Optional[PyDoughType]:

--- a/pydough/types/struct_type.py
+++ b/pydough/types/struct_type.py
@@ -48,7 +48,7 @@ class StructType(PyDoughType):
 
     # The string pattern that struct types must adhere to. The delineation
     # between the various field names/types is handled later.
-    type_string_pattern: re.Pattern = re.compile("struct\[(.+:.+)\]")
+    type_string_pattern: re.Pattern = re.compile(r"struct\[(.+:.+)\]")
 
     @staticmethod
     def parse_from_string(type_string: str) -> Optional[PyDoughType]:

--- a/pydough/types/time_type.py
+++ b/pydough/types/time_type.py
@@ -35,7 +35,7 @@ class TimeType(PyDoughType):
         return f"time[{self.precision}]"
 
     # The string pattern that time types must adhere to.
-    type_string_pattern: re.Pattern = re.compile("time\[(\d)\]")
+    type_string_pattern: re.Pattern = re.compile(r"time\[(\d)\]")
 
     @staticmethod
     def parse_from_string(type_string: str) -> Optional[PyDoughType]:

--- a/pydough/types/timestamp_type.py
+++ b/pydough/types/timestamp_type.py
@@ -52,8 +52,8 @@ class TimestampType(PyDoughType):
 
     # The string patterns that timestamp types must adhere to. Each timestamp
     # type string must match one of these patterns.
-    type_string_pattern_no_tz: re.Pattern = re.compile("timestamp\[(\d)\]")
-    type_string_pattern_with_tz: re.Pattern = re.compile("timestamp\[(\d),(.*)\]")
+    type_string_pattern_no_tz: re.Pattern = re.compile(r"timestamp\[(\d)\]")
+    type_string_pattern_with_tz: re.Pattern = re.compile(r"timestamp\[(\d),(.*)\]")
 
     @staticmethod
     def parse_from_string(type_string: str) -> Optional[PyDoughType]:


### PR DESCRIPTION
Fixes these warnings flagged by CI runs by using raw-strings:
```
pydough/types/decimal_type.py:53
  /home/runner/work/PyDough/PyDough/pydough/types/decimal_type.py:53: DeprecationWarning: invalid escape sequence '\['
    type_string_pattern: re.Pattern = re.compile("decimal\[(\d{1,2}),(\d{1,2})\]")
```