### PR TITLE
Setting up empty spec/documentation files for PyDough users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # PyDough
 
+PyDough is an alternative DSL that can be used to solve analytical problems by phrasing questions in terms of a logical document model instead of translating to relational SQL logic.
+
+## Learning About PyDough
+
+Refer to these documents to learn how to use PyDough:
+
+- [Spec for the PyDough DSL](documentation/dsl.md)
+- [Spec for the PyDough metadata](documentation/metadata.md)
+- [List of builtin PyDough functions](documentation/functions.md)
+- [Usage guide for PyDough](documentation/usage.md)
+
 ## Developing PyDough
 PyDough uses `uv` as a package manager. Please refer to their docs for
 [installation](https://docs.astral.sh/uv/getting-started/). To run testing

--- a/documentation/dsl.md
+++ b/documentation/dsl.md
@@ -1,0 +1,4 @@
+# PyDough DSL Spec
+
+TODO (gh #198): fill out this file with an extensive and exhaustive list of all features/operations in PyDough that are necessary for a user to understand what is/isn't supported in the basic DSL before any extensions, besides the specific list of supported functions.
+

--- a/documentation/functions.md
+++ b/documentation/functions.md
@@ -1,0 +1,3 @@
+# PyDough Functions List
+
+TODO (gh #199): fill out this file with a list of every function / function-like operator supported in PyDough, including their behaviors and restrictions.

--- a/documentation/metadata.md
+++ b/documentation/metadata.md
@@ -1,0 +1,3 @@
+# PyDough Metadata Spec
+
+TODO (gh #167): fill out this file with the specification of the JSON file format for PyDough metadata.

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -1,0 +1,3 @@
+# PyDough Usage Guide
+
+TODO (gh #200): fill out this file with a wholistic guide of how a user interacts with PyDough, including how to set it up, any configurations to handle, different APIs they can use, and how to run their code.

--- a/pydough/metadata/README.md
+++ b/pydough/metadata/README.md
@@ -17,4 +17,4 @@ Currently, the only way to create metadata is to store it in a JSON file that is
 
 The logic for how `parse_json_metadata_from_file` is implemented can be found in [parse.py](abstract_metadata.py).
 
-TODO (gh #167): add link to documentation for the specification of the JSON file format for PyDough metadata.
+To see the specification of the JSON file format for PyDough, [see here](../../documentation/metadata.md).


### PR DESCRIPTION
These files will be filled by #167, #198, #199, and #200.