### PR TITLE
Fix a typo in the what_if notebook

### DIFF
--- a/demos/notebooks/what_if.ipynb
+++ b/demos/notebooks/what_if.ipynb
@@ -241,7 +241,7 @@
    "source": [
     "%%pydough\n",
     "\n",
-    "order_total_price = orders(order_revenue=total_price)\n",
+    "order_total_price = orders(order_revenue=total_revenue)\n",
     "pydough.to_df(order_total_price)"
    ]
   },


### PR DESCRIPTION
Fixes a minor typo where an old name was used. Not sure why it still worked.