### PR TITLE
Automatically update defog.db whenever tests are run

### DIFF
--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -49,9 +49,6 @@ jobs:
           # Install a specific version of uv.
           version: "0.4.23"
 
-      - name: Setup Defog DB
-        run: cd tests; ./setup_defog.sh; cd ..
-
       - name: Download TPCH DB
         run: ./demos/setup_tpch.sh ./tpch.db
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ available.
 import json
 import os
 import sqlite3
+import subprocess
 from collections.abc import Callable, MutableMapping
 from functools import cache
 
@@ -365,13 +366,15 @@ def defog_graphs() -> graph_fetcher:
     return impl
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def sqlite_defog_connection() -> DatabaseContext:
     """
     Returns the SQLITE database connection for the defog database.
     """
     # Setup the directory to be the main PyDough directory.
     base_dir: str = os.path.dirname(os.path.dirname(__file__))
+    # Setup the defog database.
+    subprocess.run("cd tests; bash setup_defog.sh", shell=True)
     path: str = os.path.join(base_dir, "tests/defog.db")
     connection: sqlite3.Connection = sqlite3.connect(path)
     return DatabaseContext(DatabaseConnection(connection), DatabaseDialect.SQLITE)


### PR DESCRIPTION
Ensures that the `setup_defog.sh` script is run whenever the defog database is going to be used by the unit tests within the context of the pytest command. This ensures the relative datetimes are always up to date, and any new tables in the `init_defog.sql` script are automatically added on other branches without needing to re-run the script manually.