### PR TITLE
Fixing NDISTINCT so its output is 0 instead of NULL

### DIFF
--- a/pydough/conversion/hybrid_tree.py
+++ b/pydough/conversion/hybrid_tree.py
@@ -1649,13 +1649,16 @@ class HybridTranslator:
         """
         # If doing a SUM or AVG, and the configs are set to default those
         # functions to zero when there are no values, decorate the result
-        # with `DEFAULT_TO(x, 0)`. Also, always does this step with COUNT for
-        # left joins since the semantics of that function never allow returning
-        # NULL.
+        # with `DEFAULT_TO(x, 0)`. Also, always does this step with
+        # COUNT/NDISTINCT for left joins since the semantics of those functions
+        # never allow returning NULL.
         if (
             (agg_call.operator == pydop.SUM and self.configs.sum_default_zero)
             or (agg_call.operator == pydop.AVG and self.configs.avg_default_zero)
-            or (agg_call.operator == pydop.COUNT and joins_can_nullify)
+            or (
+                agg_call.operator in (pydop.COUNT, pydop.NDISTINCT)
+                and joins_can_nullify
+            )
         ):
             agg_ref = HybridFunctionExpr(
                 pydop.DEFAULT_TO,

--- a/tests/test_plan_refsols/tpch_q16.txt
+++ b/tests/test_plan_refsols/tpch_q16.txt
@@ -1,6 +1,6 @@
 ROOT(columns=[('P_BRAND', P_BRAND), ('P_TYPE', P_TYPE), ('P_SIZE', P_SIZE), ('SUPPLIER_COUNT', SUPPLIER_COUNT)], orderings=[(SUPPLIER_COUNT):desc_last, (P_BRAND):asc_first, (P_TYPE):asc_first, (P_SIZE):asc_first])
  LIMIT(limit=Literal(value=10, type=Int64Type()), columns={'P_BRAND': P_BRAND, 'P_SIZE': P_SIZE, 'P_TYPE': P_TYPE, 'SUPPLIER_COUNT': SUPPLIER_COUNT}, orderings=[(SUPPLIER_COUNT):desc_last, (P_BRAND):asc_first, (P_TYPE):asc_first, (P_SIZE):asc_first])
-  PROJECT(columns={'P_BRAND': p_brand, 'P_SIZE': p_size, 'P_TYPE': p_type, 'SUPPLIER_COUNT': agg_0})
+  PROJECT(columns={'P_BRAND': p_brand, 'P_SIZE': p_size, 'P_TYPE': p_type, 'SUPPLIER_COUNT': DEFAULT_TO(agg_0, 0:int64)})
    AGGREGATE(keys={'p_brand': p_brand, 'p_size': p_size, 'p_type': p_type}, aggregations={'agg_0': NDISTINCT(supplier_key)})
     FILTER(condition=NOT(LIKE(comment_2, '%Customer%Complaints%':string)), columns={'p_brand': p_brand, 'p_size': p_size, 'p_type': p_type, 'supplier_key': supplier_key})
      JOIN(conditions=[t0.supplier_key == t1.key], types=['left'], columns={'comment_2': t1.comment, 'p_brand': t0.p_brand, 'p_size': t0.p_size, 'p_type': t0.p_type, 'supplier_key': t0.supplier_key})

--- a/tests/test_sql_refsols/defog_broker_basic2_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_basic2_ansi.sql
@@ -1,7 +1,7 @@
-WITH _t0 AS (
+WITH _t1 AS (
   SELECT
-    AVG(sbtxshares) AS avg_shares,
-    COUNT(DISTINCT sbtxcustid) AS num_customers,
+    AVG(sbtxshares) AS agg_0,
+    COUNT(DISTINCT sbtxcustid) AS agg_1,
     sbtxtype AS transaction_type
   FROM main.sbtransaction
   WHERE
@@ -12,9 +12,9 @@ WITH _t0 AS (
 )
 SELECT
   transaction_type,
-  num_customers,
-  avg_shares
-FROM _t0
+  COALESCE(agg_1, 0) AS num_customers,
+  agg_0 AS avg_shares
+FROM _t1
 ORDER BY
   num_customers DESC
 LIMIT 3

--- a/tests/test_sql_refsols/defog_broker_basic2_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_basic2_sqlite.sql
@@ -1,7 +1,7 @@
-WITH _t0 AS (
+WITH _t1 AS (
   SELECT
-    AVG(sbtxshares) AS avg_shares,
-    COUNT(DISTINCT sbtxcustid) AS num_customers,
+    AVG(sbtxshares) AS agg_0,
+    COUNT(DISTINCT sbtxcustid) AS agg_1,
     sbtxtype AS transaction_type
   FROM main.sbtransaction
   WHERE
@@ -11,9 +11,9 @@ WITH _t0 AS (
 )
 SELECT
   transaction_type,
-  num_customers,
-  avg_shares
-FROM _t0
+  COALESCE(agg_1, 0) AS num_customers,
+  agg_0 AS avg_shares
+FROM _t1
 ORDER BY
   num_customers DESC
 LIMIT 3

--- a/tests/test_sql_refsols/defog_dealership_basic6_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic6_ansi.sql
@@ -11,7 +11,7 @@ WITH _t1 AS (
 )
 SELECT
   state,
-  agg_1 AS unique_customers,
+  COALESCE(agg_1, 0) AS unique_customers,
   COALESCE(agg_0, 0) AS total_revenue
 FROM _t1
 ORDER BY

--- a/tests/test_sql_refsols/defog_dealership_basic6_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic6_sqlite.sql
@@ -11,7 +11,7 @@ WITH _t1 AS (
 )
 SELECT
   state,
-  agg_1 AS unique_customers,
+  COALESCE(agg_1, 0) AS unique_customers,
   COALESCE(agg_0, 0) AS total_revenue
 FROM _t1
 ORDER BY

--- a/tests/test_sql_refsols/defog_ewallet_adv9_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv9_ansi.sql
@@ -1,10 +1,16 @@
+WITH _t0 AS (
+  SELECT
+    COUNT(DISTINCT sender_id) AS agg_0,
+    DATE_TRUNC('MONTH', CAST(created_at AS TIMESTAMP)) AS year_month
+  FROM main.wallet_transactions_daily
+  WHERE
+    created_at < DATE_TRUNC('MONTH', CURRENT_TIMESTAMP())
+    AND created_at >= DATE_ADD(DATE_TRUNC('MONTH', CURRENT_TIMESTAMP()), -2, 'MONTH')
+    AND sender_type = 0
+  GROUP BY
+    DATE_TRUNC('MONTH', CAST(created_at AS TIMESTAMP))
+)
 SELECT
-  DATE_TRUNC('MONTH', CAST(created_at AS TIMESTAMP)) AS year_month,
-  COUNT(DISTINCT sender_id) AS active_users
-FROM main.wallet_transactions_daily
-WHERE
-  created_at < DATE_TRUNC('MONTH', CURRENT_TIMESTAMP())
-  AND created_at >= DATE_ADD(DATE_TRUNC('MONTH', CURRENT_TIMESTAMP()), -2, 'MONTH')
-  AND sender_type = 0
-GROUP BY
-  DATE_TRUNC('MONTH', CAST(created_at AS TIMESTAMP))
+  year_month,
+  COALESCE(agg_0, 0) AS active_users
+FROM _t0

--- a/tests/test_sql_refsols/defog_ewallet_adv9_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv9_sqlite.sql
@@ -1,10 +1,16 @@
+WITH _t0 AS (
+  SELECT
+    COUNT(DISTINCT sender_id) AS agg_0,
+    DATE(created_at, 'start of month') AS year_month
+  FROM main.wallet_transactions_daily
+  WHERE
+    created_at < DATE('now', 'start of month')
+    AND created_at >= DATE('now', 'start of month', '-2 month')
+    AND sender_type = 0
+  GROUP BY
+    DATE(created_at, 'start of month')
+)
 SELECT
-  DATE(created_at, 'start of month') AS year_month,
-  COUNT(DISTINCT sender_id) AS active_users
-FROM main.wallet_transactions_daily
-WHERE
-  created_at < DATE('now', 'start of month')
-  AND created_at >= DATE('now', 'start of month', '-2 month')
-  AND sender_type = 0
-GROUP BY
-  DATE(created_at, 'start of month')
+  year_month,
+  COALESCE(agg_0, 0) AS active_users
+FROM _t0

--- a/tests/test_sql_refsols/defog_ewallet_basic1_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic1_ansi.sql
@@ -1,12 +1,18 @@
+WITH _t0 AS (
+  SELECT
+    COUNT(DISTINCT wallet_transactions_daily.sender_id) AS agg_0,
+    DATE_TRUNC('MONTH', CAST(wallet_transactions_daily.created_at AS TIMESTAMP)) AS month
+  FROM main.wallet_transactions_daily AS wallet_transactions_daily
+  JOIN main.users AS users
+    ON users.status = 'active' AND users.uid = wallet_transactions_daily.sender_id
+  WHERE
+    EXTRACT(YEAR FROM wallet_transactions_daily.created_at) = 2023
+    AND wallet_transactions_daily.sender_type = 0
+    AND wallet_transactions_daily.status = 'success'
+  GROUP BY
+    DATE_TRUNC('MONTH', CAST(wallet_transactions_daily.created_at AS TIMESTAMP))
+)
 SELECT
-  DATE_TRUNC('MONTH', CAST(wallet_transactions_daily.created_at AS TIMESTAMP)) AS month,
-  COUNT(DISTINCT wallet_transactions_daily.sender_id) AS active_users
-FROM main.wallet_transactions_daily AS wallet_transactions_daily
-JOIN main.users AS users
-  ON users.status = 'active' AND users.uid = wallet_transactions_daily.sender_id
-WHERE
-  EXTRACT(YEAR FROM wallet_transactions_daily.created_at) = 2023
-  AND wallet_transactions_daily.sender_type = 0
-  AND wallet_transactions_daily.status = 'success'
-GROUP BY
-  DATE_TRUNC('MONTH', CAST(wallet_transactions_daily.created_at AS TIMESTAMP))
+  month,
+  COALESCE(agg_0, 0) AS active_users
+FROM _t0

--- a/tests/test_sql_refsols/defog_ewallet_basic1_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic1_sqlite.sql
@@ -1,12 +1,18 @@
+WITH _t0 AS (
+  SELECT
+    COUNT(DISTINCT wallet_transactions_daily.sender_id) AS agg_0,
+    DATE(wallet_transactions_daily.created_at, 'start of month') AS month
+  FROM main.wallet_transactions_daily AS wallet_transactions_daily
+  JOIN main.users AS users
+    ON users.status = 'active' AND users.uid = wallet_transactions_daily.sender_id
+  WHERE
+    CAST(STRFTIME('%Y', wallet_transactions_daily.created_at) AS INTEGER) = 2023
+    AND wallet_transactions_daily.sender_type = 0
+    AND wallet_transactions_daily.status = 'success'
+  GROUP BY
+    DATE(wallet_transactions_daily.created_at, 'start of month')
+)
 SELECT
-  DATE(wallet_transactions_daily.created_at, 'start of month') AS month,
-  COUNT(DISTINCT wallet_transactions_daily.sender_id) AS active_users
-FROM main.wallet_transactions_daily AS wallet_transactions_daily
-JOIN main.users AS users
-  ON users.status = 'active' AND users.uid = wallet_transactions_daily.sender_id
-WHERE
-  CAST(STRFTIME('%Y', wallet_transactions_daily.created_at) AS INTEGER) = 2023
-  AND wallet_transactions_daily.sender_type = 0
-  AND wallet_transactions_daily.status = 'success'
-GROUP BY
-  DATE(wallet_transactions_daily.created_at, 'start of month')
+  month,
+  COALESCE(agg_0, 0) AS active_users
+FROM _t0

--- a/tests/test_sql_refsols/defog_ewallet_basic9_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic9_ansi.sql
@@ -13,7 +13,7 @@ WITH _t1 AS (
 )
 SELECT
   country,
-  agg_1 AS user_count,
+  COALESCE(agg_1, 0) AS user_count,
   COALESCE(agg_0, 0) AS total_amount
 FROM _t1
 ORDER BY

--- a/tests/test_sql_refsols/defog_ewallet_basic9_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic9_sqlite.sql
@@ -13,7 +13,7 @@ WITH _t1 AS (
 )
 SELECT
   country,
-  agg_1 AS user_count,
+  COALESCE(agg_1, 0) AS user_count,
   COALESCE(agg_0, 0) AS total_amount
 FROM _t1
 ORDER BY

--- a/tests/test_sql_refsols/tpch_q16_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q16_ansi.sql
@@ -1,6 +1,6 @@
-WITH _t0 AS (
+WITH _t1 AS (
   SELECT
-    COUNT(DISTINCT partsupp.ps_suppkey) AS supplier_count,
+    COUNT(DISTINCT partsupp.ps_suppkey) AS agg_0,
     part.p_brand,
     part.p_size,
     part.p_type
@@ -23,8 +23,8 @@ SELECT
   p_brand AS P_BRAND,
   p_type AS P_TYPE,
   p_size AS P_SIZE,
-  supplier_count AS SUPPLIER_COUNT
-FROM _t0
+  COALESCE(agg_0, 0) AS SUPPLIER_COUNT
+FROM _t1
 ORDER BY
   supplier_count DESC,
   p_brand,

--- a/tests/test_sql_refsols/tpch_q16_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q16_sqlite.sql
@@ -1,6 +1,6 @@
-WITH _t0 AS (
+WITH _t1 AS (
   SELECT
-    COUNT(DISTINCT partsupp.ps_suppkey) AS supplier_count,
+    COUNT(DISTINCT partsupp.ps_suppkey) AS agg_0,
     part.p_brand,
     part.p_size,
     part.p_type
@@ -23,8 +23,8 @@ SELECT
   p_brand AS P_BRAND,
   p_type AS P_TYPE,
   p_size AS P_SIZE,
-  supplier_count AS SUPPLIER_COUNT
-FROM _t0
+  COALESCE(agg_0, 0) AS SUPPLIER_COUNT
+FROM _t1
 ORDER BY
   supplier_count DESC,
   p_brand,


### PR DESCRIPTION
Adding a bugfix to the behavior of `NDISTINCT` to have the same zero-coalescing behavior as `COUNT`.