### PR TITLE
Replace COUNT() with COUNT(*)

### DIFF
--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -401,7 +401,7 @@ FROM (
         WHERE name_3 = 'EUROPE'
     )
     LEFT JOIN (
-        SELECT nation_key, COUNT() AS agg_0
+        SELECT nation_key, COUNT(*) AS agg_0
         FROM (
             SELECT c_nationkey AS nation_key
             FROM main.CUSTOMER

--- a/pydough/pydough_operators/expression_operators/registered_expression_operators.py
+++ b/pydough/pydough_operators/expression_operators/registered_expression_operators.py
@@ -170,7 +170,7 @@ SIGN = ExpressionFunctionOperator(
     "SIGN", False, RequireNumArgs(1), ConstantType(NumericType())
 )
 COUNT = ExpressionFunctionOperator(
-    "COUNT", True, AllowAny(), ConstantType(NumericType())
+    "COUNT", True, RequireNumArgs(1), ConstantType(NumericType())
 )
 HAS = ExpressionFunctionOperator(
     "HAS", True, RequireCollection(), ConstantType(BooleanType())

--- a/pydough/sqlglot/transform_bindings/base_transform_bindings.py
+++ b/pydough/sqlglot/transform_bindings/base_transform_bindings.py
@@ -83,7 +83,6 @@ class BaseTransformBindings:
     ] = {
         pydop.SUM: sqlglot_expressions.Sum,
         pydop.AVG: sqlglot_expressions.Avg,
-        pydop.COUNT: sqlglot_expressions.Count,
         pydop.MIN: sqlglot_expressions.Min,
         pydop.MAX: sqlglot_expressions.Max,
         pydop.ANYTHING: sqlglot_expressions.AnyValue,
@@ -248,6 +247,8 @@ class BaseTransformBindings:
                 return self.convert_smallest_or_largest(args, types, False)
             case pydop.LARGEST:
                 return self.convert_smallest_or_largest(args, types, True)
+            case pydop.COUNT:
+                return self.convert_count(args)
             case _:
                 raise NotImplementedError(
                     f"Operator '{operator.function_name}' is unsupported with this database dialect."
@@ -1666,3 +1667,19 @@ class BaseTransformBindings:
             return sqlglot_expressions.StddevPop(this=args[0])
         elif type == "sample":
             return sqlglot_expressions.Stddev(this=args[0])
+
+    def convert_count(self, args: list[SQLGlotExpression]) -> SQLGlotExpression:
+        """
+        Converts a COUNT operation to an equivalent SQLGlot expression.
+        Args:
+            `args`: The arguments to the COUNT function.
+        Returns:
+            The SQLGlot expression to calculate the count of the argument.
+        """
+        # If COUNT is called with no arguments, make it COUNT(*).
+        if len(args) == 0:
+            return sqlglot_expressions.Count(this=sqlglot_expressions.Star())
+        elif len(args) == 1:
+            return sqlglot_expressions.Count(this=args[0])
+        else:
+            raise ValueError(f"COUNT expects 0 or 1 argument, got {len(args)}")

--- a/pydough/sqlglot/transform_bindings/base_transform_bindings.py
+++ b/pydough/sqlglot/transform_bindings/base_transform_bindings.py
@@ -248,7 +248,7 @@ class BaseTransformBindings:
             case pydop.LARGEST:
                 return self.convert_smallest_or_largest(args, types, True)
             case pydop.COUNT:
-                return self.convert_count(args)
+                return self.convert_count(args, types)
             case _:
                 raise NotImplementedError(
                     f"Operator '{operator.function_name}' is unsupported with this database dialect."
@@ -1668,15 +1668,19 @@ class BaseTransformBindings:
         elif type == "sample":
             return sqlglot_expressions.Stddev(this=args[0])
 
-    def convert_count(self, args: list[SQLGlotExpression]) -> SQLGlotExpression:
+    def convert_count(
+        self, args: list[SQLGlotExpression], types: list[PyDoughType]
+    ) -> SQLGlotExpression:
         """
         Converts a COUNT operation to an equivalent SQLGlot expression.
         Args:
             `args`: The arguments to the COUNT function.
+            `types`: The PyDough types of the arguments to the function call.
         Returns:
             The SQLGlot expression to calculate the count of the argument.
         """
         # If COUNT is called with no arguments, make it COUNT(*).
+        # since only some databases allow calling COUNT with no arguments.
         if len(args) == 0:
             return sqlglot_expressions.Count(this=sqlglot_expressions.Star())
         elif len(args) == 1:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -184,7 +184,7 @@ def test_execute_df_logging(
 [INFO] pydough.sqlglot.execute_relational: SQL query:
  WITH _t0 AS (
   SELECT
-    COUNT() AS count_order,
+    COUNT(*) AS count_order,
     SUM(l_extendedprice) AS sum_base_price,
     SUM(l_extendedprice * (
       1 - l_discount

--- a/tests/test_sql_refsols/defog_broker_adv10_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv10_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     sbcustomer.sbcustid AS _id
   FROM main.sbcustomer AS sbcustomer
   JOIN main.sbtransaction AS sbtransaction

--- a/tests/test_sql_refsols/defog_broker_adv10_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv10_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     sbcustomer.sbcustid AS _id
   FROM main.sbcustomer AS sbcustomer
   JOIN main.sbtransaction AS sbtransaction

--- a/tests/test_sql_refsols/defog_broker_adv11_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv11_ansi.sql
@@ -45,5 +45,5 @@ WITH _t1 AS (
     )
 )
 SELECT
-  COUNT() AS n_customers
+  COUNT(*) AS n_customers
 FROM _t0 AS _t0

--- a/tests/test_sql_refsols/defog_broker_adv11_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv11_sqlite.sql
@@ -45,5 +45,5 @@ WITH _t1 AS (
     )
 )
 SELECT
-  COUNT() AS n_customers
+  COUNT(*) AS n_customers
 FROM _t0 AS _t0

--- a/tests/test_sql_refsols/defog_broker_adv12_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv12_ansi.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS n_customers
+  COUNT(*) AS n_customers
 FROM main.sbcustomer
 WHERE
   (

--- a/tests/test_sql_refsols/defog_broker_adv12_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv12_sqlite.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS n_customers
+  COUNT(*) AS n_customers
 FROM main.sbcustomer
 WHERE
   (

--- a/tests/test_sql_refsols/defog_broker_adv13_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv13_ansi.sql
@@ -1,6 +1,6 @@
 SELECT
   sbcustcountry AS cust_country,
-  COUNT() AS TAC
+  COUNT(*) AS TAC
 FROM main.sbcustomer
 WHERE
   sbcustjoindate >= CAST('2023-01-01' AS DATE)

--- a/tests/test_sql_refsols/defog_broker_adv13_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv13_sqlite.sql
@@ -1,6 +1,6 @@
 SELECT
   sbcustcountry AS cust_country,
-  COUNT() AS TAC
+  COUNT(*) AS TAC
 FROM main.sbcustomer
 WHERE
   sbcustjoindate >= '2023-01-01'

--- a/tests/test_sql_refsols/defog_broker_adv15_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv15_ansi.sql
@@ -1,7 +1,7 @@
 WITH _t0 AS (
   SELECT
     SUM(sbcuststatus = 'active') AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     sbcustcountry AS country
   FROM main.sbcustomer
   WHERE

--- a/tests/test_sql_refsols/defog_broker_adv15_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv15_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _t0 AS (
   SELECT
     SUM(sbcuststatus = 'active') AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     sbcustcountry AS country
   FROM main.sbcustomer
   WHERE

--- a/tests/test_sql_refsols/defog_broker_adv2_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv2_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     sbtxtickerid AS ticker_id
   FROM main.sbtransaction
   WHERE

--- a/tests/test_sql_refsols/defog_broker_adv2_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv2_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     sbtxtickerid AS ticker_id
   FROM main.sbtransaction
   WHERE

--- a/tests/test_sql_refsols/defog_broker_adv3_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv3_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sbtxstatus = 'success') AS agg_1,
     sbtxcustid AS customer_id
   FROM main.sbtransaction

--- a/tests/test_sql_refsols/defog_broker_adv3_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv3_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sbtxstatus = 'success') AS agg_1,
     sbtxcustid AS customer_id
   FROM main.sbtransaction

--- a/tests/test_sql_refsols/defog_broker_adv6_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv6_ansi.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(sbtxamount) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     sbtxcustid AS customer_id
   FROM main.sbtransaction
   GROUP BY

--- a/tests/test_sql_refsols/defog_broker_adv6_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv6_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(sbtxamount) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     sbtxcustid AS customer_id
   FROM main.sbtransaction
   GROUP BY

--- a/tests/test_sql_refsols/defog_broker_adv7_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv7_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s2 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     CONCAT_WS(
       '-',
       EXTRACT(YEAR FROM sbcustjoindate),

--- a/tests/test_sql_refsols/defog_broker_adv7_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv7_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s2 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     CONCAT_WS(
       '-',
       CAST(STRFTIME('%Y', sbcustjoindate) AS INTEGER),

--- a/tests/test_sql_refsols/defog_broker_adv8_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv8_ansi.sql
@@ -14,7 +14,7 @@ WITH _t4 AS (
     AND _t4.date_time >= DATE_ADD(DATE_TRUNC('WEEK', CURRENT_TIMESTAMP()), -1, 'WEEK')
 ), _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(_t3.amount) AS agg_1,
     _t3.customer_id AS customer_id
   FROM _t3 AS _t3

--- a/tests/test_sql_refsols/defog_broker_adv8_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv8_sqlite.sql
@@ -27,7 +27,7 @@ WITH _t4 AS (
     )
 ), _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(_t3.amount) AS agg_1,
     _t3.customer_id AS customer_id
   FROM _t3 AS _t3

--- a/tests/test_sql_refsols/defog_broker_adv9_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_adv9_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM((
       (
         DAY_OF_WEEK(sbtxdatetime) + 6

--- a/tests/test_sql_refsols/defog_broker_adv9_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_adv9_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM((
       (
         CAST(STRFTIME('%w', sbtxdatetime) AS INTEGER) + 6

--- a/tests/test_sql_refsols/defog_broker_basic1_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_basic1_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     SUM(sbtxamount) AS agg_5,
     sbtxcustid AS customer_id
   FROM main.sbtransaction

--- a/tests/test_sql_refsols/defog_broker_basic1_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_basic1_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     SUM(sbtxamount) AS agg_5,
     sbtxcustid AS customer_id
   FROM main.sbtransaction

--- a/tests/test_sql_refsols/defog_broker_basic3_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_basic3_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sbtxamount) AS agg_1,
     sbtxtickerid AS ticker_id
   FROM main.sbtransaction

--- a/tests/test_sql_refsols/defog_broker_basic3_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_basic3_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sbtxamount) AS agg_1,
     sbtxtickerid AS ticker_id
   FROM main.sbtransaction

--- a/tests/test_sql_refsols/defog_broker_basic4_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_basic4_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS num_transactions,
+    COUNT(*) AS num_transactions,
     sbcustomer.sbcuststate AS state,
     sbticker.sbtickertype AS ticker_type
   FROM main.sbtransaction AS sbtransaction

--- a/tests/test_sql_refsols/defog_broker_basic4_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_basic4_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS num_transactions,
+    COUNT(*) AS num_transactions,
     sbcustomer.sbcuststate AS state,
     sbticker.sbtickertype AS ticker_type
   FROM main.sbtransaction AS sbtransaction

--- a/tests/test_sql_refsols/defog_broker_basic7_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_basic7_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS num_transactions,
+    COUNT(*) AS num_transactions,
     sbtxstatus AS status
   FROM main.sbtransaction
   GROUP BY

--- a/tests/test_sql_refsols/defog_broker_basic7_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_basic7_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS num_transactions,
+    COUNT(*) AS num_transactions,
     sbtxstatus AS status
   FROM main.sbtransaction
   GROUP BY

--- a/tests/test_sql_refsols/defog_broker_basic8_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_basic8_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS num_customers,
+    COUNT(*) AS num_customers,
     sbcustcountry AS country
   FROM main.sbcustomer
   GROUP BY

--- a/tests/test_sql_refsols/defog_broker_basic8_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_basic8_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS num_customers,
+    COUNT(*) AS num_customers,
     sbcustcountry AS country
   FROM main.sbcustomer
   GROUP BY

--- a/tests/test_sql_refsols/defog_broker_gen4_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_gen4_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     sbtxcustid AS customer_id
   FROM main.sbtransaction
   WHERE

--- a/tests/test_sql_refsols/defog_broker_gen4_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_gen4_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     sbtxcustid AS customer_id
   FROM main.sbtransaction
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_adv14_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv14_ansi.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS TSC
+  COUNT(*) AS TSC
 FROM main.sales
 WHERE
   DATEDIFF(CURRENT_TIMESTAMP(), sale_date, DAY) <= 7

--- a/tests/test_sql_refsols/defog_dealership_adv14_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv14_sqlite.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS TSC
+  COUNT(*) AS TSC
 FROM main.sales
 WHERE
   CAST((

--- a/tests/test_sql_refsols/defog_dealership_adv1_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv1_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM((
       (
         DAY_OF_WEEK(payment_date) + 6

--- a/tests/test_sql_refsols/defog_dealership_adv1_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv1_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM((
       (
         CAST(STRFTIME('%w', payment_date) AS INTEGER) + 6

--- a/tests/test_sql_refsols/defog_dealership_adv2_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv2_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS num_sales,
+    COUNT(*) AS num_sales,
     salesperson_id
   FROM main.sales
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_adv2_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv2_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS num_sales,
+    COUNT(*) AS num_sales,
     salesperson_id
   FROM main.sales
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_adv3_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv3_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     car_id
   FROM main.sales
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_adv3_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv3_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     car_id
   FROM main.sales
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_adv4_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv4_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sale_price) AS agg_1,
     car_id
   FROM main.sales

--- a/tests/test_sql_refsols/defog_dealership_adv4_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv4_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sale_price) AS agg_1,
     car_id
   FROM main.sales

--- a/tests/test_sql_refsols/defog_dealership_adv5_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv5_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sale_price) AS agg_1,
     salesperson_id
   FROM main.sales

--- a/tests/test_sql_refsols/defog_dealership_adv5_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_adv5_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(sale_price) AS agg_1,
     salesperson_id
   FROM main.sales

--- a/tests/test_sql_refsols/defog_dealership_basic10_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic10_ansi.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(sale_price) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     salesperson_id
   FROM main.sales
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_basic10_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic10_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(sale_price) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     salesperson_id
   FROM main.sales
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_basic5_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic5_ansi.sql
@@ -1,7 +1,7 @@
 WITH _t0 AS (
   SELECT
     SUM(sale_price) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     salesperson_id
   FROM main.sales
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_basic5_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic5_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _t0 AS (
   SELECT
     SUM(sale_price) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     salesperson_id
   FROM main.sales
   WHERE

--- a/tests/test_sql_refsols/defog_dealership_basic7_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic7_ansi.sql
@@ -1,7 +1,7 @@
 WITH _t1 AS (
   SELECT
     SUM(payment_amount) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     payment_method
   FROM main.payments_received
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_basic7_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic7_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _t1 AS (
   SELECT
     SUM(payment_amount) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     payment_method
   FROM main.payments_received
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_basic8_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic8_ansi.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(sale_price) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     car_id
   FROM main.sales
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_basic8_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic8_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(sale_price) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     car_id
   FROM main.sales
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_basic9_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic9_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS total_signups,
+    COUNT(*) AS total_signups,
     state
   FROM main.customers
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_basic9_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_basic9_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS total_signups,
+    COUNT(*) AS total_signups,
     state
   FROM main.customers
   GROUP BY

--- a/tests/test_sql_refsols/defog_dealership_gen2_ansi.sql
+++ b/tests/test_sql_refsols/defog_dealership_gen2_ansi.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS weekend_payments
+  COUNT(*) AS weekend_payments
 FROM main.payments_made
 WHERE
   (

--- a/tests/test_sql_refsols/defog_dealership_gen2_sqlite.sql
+++ b/tests/test_sql_refsols/defog_dealership_gen2_sqlite.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS weekend_payments
+  COUNT(*) AS weekend_payments
 FROM main.payments_made
 WHERE
   (

--- a/tests/test_sql_refsols/defog_ewallet_adv10_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv10_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS total_transactions,
+    COUNT(*) AS total_transactions,
     sender_id
   FROM main.wallet_transactions_daily
   WHERE

--- a/tests/test_sql_refsols/defog_ewallet_adv10_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv10_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS total_transactions,
+    COUNT(*) AS total_transactions,
     sender_id
   FROM main.wallet_transactions_daily
   WHERE

--- a/tests/test_sql_refsols/defog_ewallet_adv13_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv13_ansi.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS TUC
+  COUNT(*) AS TUC
 FROM main.user_sessions
 WHERE
   session_start_ts >= DATE_TRUNC('DAY', DATE_ADD(CURRENT_TIMESTAMP(), -1, 'MONTH'))

--- a/tests/test_sql_refsols/defog_ewallet_adv13_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv13_sqlite.sql
@@ -1,5 +1,5 @@
 SELECT
-  COUNT() AS TUC
+  COUNT(*) AS TUC
 FROM main.user_sessions
 WHERE
   session_start_ts >= DATE(DATETIME('now', '-1 month'), 'start of day')

--- a/tests/test_sql_refsols/defog_ewallet_adv14_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv14_ansi.sql
@@ -1,7 +1,7 @@
 WITH _t0 AS (
   SELECT
     SUM(status = 'success') AS agg_0,
-    COUNT() AS agg_1
+    COUNT(*) AS agg_1
   FROM main.wallet_transactions_daily
   WHERE
     DATEDIFF(CURRENT_TIMESTAMP(), created_at, MONTH) = 1

--- a/tests/test_sql_refsols/defog_ewallet_adv14_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv14_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _t0 AS (
   SELECT
     SUM(status = 'success') AS agg_0,
-    COUNT() AS agg_1
+    COUNT(*) AS agg_1
   FROM main.wallet_transactions_daily
   WHERE
     (

--- a/tests/test_sql_refsols/defog_ewallet_adv15_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv15_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     coupons.merchant_id
   FROM main.coupons AS coupons
   JOIN main.merchants AS merchants

--- a/tests/test_sql_refsols/defog_ewallet_adv15_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv15_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     coupons.merchant_id
   FROM main.coupons AS coupons
   JOIN main.merchants AS merchants

--- a/tests/test_sql_refsols/defog_ewallet_adv16_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv16_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS total_unread_notifs,
+    COUNT(*) AS total_unread_notifs,
     user_id
   FROM main.notifications
   WHERE

--- a/tests/test_sql_refsols/defog_ewallet_adv16_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv16_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS total_unread_notifs,
+    COUNT(*) AS total_unread_notifs,
     user_id
   FROM main.notifications
   WHERE

--- a/tests/test_sql_refsols/defog_ewallet_adv2_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv2_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM((
       (
         DAY_OF_WEEK(created_at) + 6

--- a/tests/test_sql_refsols/defog_ewallet_adv2_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv2_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM((
       (
         CAST(STRFTIME('%w', created_at) AS INTEGER) + 6

--- a/tests/test_sql_refsols/defog_ewallet_adv3_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv3_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS total_coupons,
+    COUNT(*) AS total_coupons,
     merchant_id
   FROM main.coupons
   GROUP BY

--- a/tests/test_sql_refsols/defog_ewallet_adv3_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv3_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS total_coupons,
+    COUNT(*) AS total_coupons,
     merchant_id
   FROM main.coupons
   GROUP BY

--- a/tests/test_sql_refsols/defog_ewallet_adv4_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv4_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(amount) AS agg_1,
     sender_id
   FROM main.wallet_transactions_daily

--- a/tests/test_sql_refsols/defog_ewallet_adv4_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_adv4_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     SUM(amount) AS agg_1,
     sender_id
   FROM main.wallet_transactions_daily

--- a/tests/test_sql_refsols/defog_ewallet_basic10_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic10_ansi.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(amount) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     receiver_id
   FROM main.wallet_transactions_daily
   WHERE

--- a/tests/test_sql_refsols/defog_ewallet_basic10_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic10_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _s1 AS (
   SELECT
     SUM(amount) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     receiver_id
   FROM main.wallet_transactions_daily
   WHERE

--- a/tests/test_sql_refsols/defog_ewallet_basic6_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic6_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS count,
+    COUNT(*) AS count,
     device_type
   FROM main.user_sessions
   GROUP BY

--- a/tests/test_sql_refsols/defog_ewallet_basic6_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic6_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS count,
+    COUNT(*) AS count,
     device_type
   FROM main.user_sessions
   GROUP BY

--- a/tests/test_sql_refsols/defog_ewallet_basic7_ansi.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic7_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS count,
+    COUNT(*) AS count,
     status
   FROM main.wallet_transactions_daily
   GROUP BY

--- a/tests/test_sql_refsols/defog_ewallet_basic7_sqlite.sql
+++ b/tests/test_sql_refsols/defog_ewallet_basic7_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS count,
+    COUNT(*) AS count,
     status
   FROM main.wallet_transactions_daily
   GROUP BY

--- a/tests/test_sql_refsols/epoch_events_per_season_ansi.sql
+++ b/tests/test_sql_refsols/epoch_events_per_season_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS n_events,
+    COUNT(*) AS n_events,
     ANY_VALUE(seasons.s_name) AS season_name
   FROM seasons AS seasons
   JOIN events AS events

--- a/tests/test_sql_refsols/epoch_events_per_season_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_events_per_season_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t0 AS (
   SELECT
-    COUNT() AS n_events,
+    COUNT(*) AS n_events,
     MAX(seasons.s_name) AS season_name
   FROM seasons AS seasons
   JOIN events AS events

--- a/tests/test_sql_refsols/epoch_intra_season_searches_ansi.sql
+++ b/tests/test_sql_refsols/epoch_intra_season_searches_ansi.sql
@@ -15,7 +15,7 @@ WITH _s0 AS (
   FROM seasons
 ), _s9 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     _s2.name,
     searches.search_id
   FROM _s0 AS _s2
@@ -40,7 +40,7 @@ WITH _s0 AS (
     SUM((
       NOT _s9.agg_0 IS NULL AND _s9.agg_0 > 0
     )) AS agg_2,
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     ANY_VALUE(_s0.season_name) AS agg_4
   FROM _s0 AS _s0
   JOIN searches AS searches
@@ -54,7 +54,7 @@ WITH _s0 AS (
 ), _s17 AS (
   SELECT
     SUM(_s10.season_name = _s15.name) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     _s10.name
   FROM _s0 AS _s10
   JOIN events AS events

--- a/tests/test_sql_refsols/epoch_intra_season_searches_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_intra_season_searches_sqlite.sql
@@ -15,7 +15,7 @@ WITH _s0 AS (
   FROM seasons
 ), _s9 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     _s2.name,
     searches.search_id
   FROM _s0 AS _s2
@@ -42,7 +42,7 @@ WITH _s0 AS (
     SUM((
       NOT _s9.agg_0 IS NULL AND _s9.agg_0 > 0
     )) AS agg_2,
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     MAX(_s0.season_name) AS agg_4
   FROM _s0 AS _s0
   JOIN searches AS searches
@@ -56,7 +56,7 @@ WITH _s0 AS (
 ), _s17 AS (
   SELECT
     SUM(_s10.season_name = _s15.name) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     _s10.name
   FROM _s0 AS _s10
   JOIN events AS events

--- a/tests/test_sql_refsols/epoch_most_popular_search_engine_per_tod_ansi.sql
+++ b/tests/test_sql_refsols/epoch_most_popular_search_engine_per_tod_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t1 AS (
   SELECT
-    COUNT() AS n_searches,
+    COUNT(*) AS n_searches,
     searches.search_engine,
     times.t_name AS tod
   FROM times AS times

--- a/tests/test_sql_refsols/epoch_most_popular_search_engine_per_tod_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_most_popular_search_engine_per_tod_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t1 AS (
   SELECT
-    COUNT() AS n_searches,
+    COUNT(*) AS n_searches,
     searches.search_engine,
     times.t_name AS tod
   FROM times AS times

--- a/tests/test_sql_refsols/epoch_num_predawn_cold_war_ansi.sql
+++ b/tests/test_sql_refsols/epoch_num_predawn_cold_war_ansi.sql
@@ -56,5 +56,5 @@ WITH _s1 AS (
     )
 )
 SELECT
-  COUNT() AS n_events
+  COUNT(*) AS n_events
 FROM _t0 AS _t0

--- a/tests/test_sql_refsols/epoch_num_predawn_cold_war_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_num_predawn_cold_war_sqlite.sql
@@ -56,5 +56,5 @@ WITH _s1 AS (
     )
 )
 SELECT
-  COUNT() AS n_events
+  COUNT(*) AS n_events
 FROM _t0 AS _t0

--- a/tests/test_sql_refsols/epoch_overlapping_event_searches_per_user_ansi.sql
+++ b/tests/test_sql_refsols/epoch_overlapping_event_searches_per_user_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t2 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     ANY_VALUE(users.user_id) AS agg_10,
     ANY_VALUE(users.user_name) AS agg_8
   FROM users AS users
@@ -20,7 +20,7 @@ WITH _t2 AS (
 ), _t0 AS (
   SELECT
     ANY_VALUE(agg_8) AS agg_2,
-    COUNT() AS n_searches,
+    COUNT(*) AS n_searches,
     ANY_VALUE(agg_8) AS user_name
   FROM _t2
   WHERE

--- a/tests/test_sql_refsols/epoch_overlapping_event_searches_per_user_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_overlapping_event_searches_per_user_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t2 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     MAX(users.user_id) AS agg_10,
     MAX(users.user_name) AS agg_8
   FROM users AS users
@@ -24,7 +24,7 @@ WITH _t2 AS (
 ), _t0 AS (
   SELECT
     MAX(agg_8) AS agg_2,
-    COUNT() AS n_searches,
+    COUNT(*) AS n_searches,
     MAX(agg_8) AS user_name
   FROM _t2
   WHERE

--- a/tests/test_sql_refsols/epoch_pct_searches_per_tod_ansi.sql
+++ b/tests/test_sql_refsols/epoch_pct_searches_per_tod_ansi.sql
@@ -1,6 +1,6 @@
 WITH _t1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     ANY_VALUE(times.t_name) AS agg_2,
     ANY_VALUE(times.t_start_hour) AS agg_3
   FROM times AS times

--- a/tests/test_sql_refsols/epoch_pct_searches_per_tod_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_pct_searches_per_tod_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _t1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     MAX(times.t_name) AS agg_2,
     MAX(times.t_start_hour) AS agg_3
   FROM times AS times

--- a/tests/test_sql_refsols/epoch_search_results_by_tod_ansi.sql
+++ b/tests/test_sql_refsols/epoch_search_results_by_tod_ansi.sql
@@ -1,7 +1,7 @@
 WITH _t1 AS (
   SELECT
     AVG(searches.search_num_results) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     ANY_VALUE(times.t_name) AS agg_3,
     ANY_VALUE(times.t_start_hour) AS agg_4
   FROM times AS times

--- a/tests/test_sql_refsols/epoch_search_results_by_tod_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_search_results_by_tod_sqlite.sql
@@ -1,7 +1,7 @@
 WITH _t1 AS (
   SELECT
     AVG(searches.search_num_results) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     MAX(times.t_name) AS agg_3,
     MAX(times.t_start_hour) AS agg_4
   FROM times AS times

--- a/tests/test_sql_refsols/epoch_summer_events_per_type_ansi.sql
+++ b/tests/test_sql_refsols/epoch_summer_events_per_type_ansi.sql
@@ -1,6 +1,6 @@
 SELECT
   events.ev_typ AS event_type,
-  COUNT() AS n_events
+  COUNT(*) AS n_events
 FROM events AS events
 JOIN seasons AS seasons
   ON (

--- a/tests/test_sql_refsols/epoch_summer_events_per_type_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_summer_events_per_type_sqlite.sql
@@ -1,6 +1,6 @@
 SELECT
   events.ev_typ AS event_type,
-  COUNT() AS n_events
+  COUNT(*) AS n_events
 FROM events AS events
 JOIN seasons AS seasons
   ON (

--- a/tests/test_sql_refsols/epoch_users_most_cold_war_searches_ansi.sql
+++ b/tests/test_sql_refsols/epoch_users_most_cold_war_searches_ansi.sql
@@ -47,7 +47,7 @@ WITH _s4 AS (
     )
 ), _s5 AS (
   SELECT
-    COUNT() AS n_cold_war_searches,
+    COUNT(*) AS n_cold_war_searches,
     _t0.user_id AS user_id
   FROM _t0 AS _t0
   GROUP BY

--- a/tests/test_sql_refsols/epoch_users_most_cold_war_searches_sqlite.sql
+++ b/tests/test_sql_refsols/epoch_users_most_cold_war_searches_sqlite.sql
@@ -49,7 +49,7 @@ WITH _s4 AS (
     )
 ), _s5 AS (
   SELECT
-    COUNT() AS n_cold_war_searches,
+    COUNT(*) AS n_cold_war_searches,
     _t0.user_id AS user_id
   FROM _t0 AS _t0
   GROUP BY

--- a/tests/test_sql_refsols/technograph_battery_failure_rates_anomalies_ansi.sql
+++ b/tests/test_sql_refsols/technograph_battery_failure_rates_anomalies_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s7 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     incidents.in_device_id AS device_id
   FROM main.incidents AS incidents
   JOIN main.errors AS errors
@@ -10,7 +10,7 @@ WITH _s7 AS (
 ), _t1 AS (
   SELECT
     SUM(COALESCE(_s7.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     countries.co_name AS country_name,
     products.pr_name AS product_name
   FROM main.countries AS countries

--- a/tests/test_sql_refsols/technograph_battery_failure_rates_anomalies_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_battery_failure_rates_anomalies_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s7 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     incidents.in_device_id AS device_id
   FROM main.incidents AS incidents
   JOIN main.errors AS errors
@@ -10,7 +10,7 @@ WITH _s7 AS (
 ), _t1 AS (
   SELECT
     SUM(COALESCE(_s7.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     countries.co_name AS country_name,
     products.pr_name AS product_name
   FROM main.countries AS countries

--- a/tests/test_sql_refsols/technograph_country_cartesian_oddball_ansi.sql
+++ b/tests/test_sql_refsols/technograph_country_cartesian_oddball_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS n_other_countries
+    COUNT(*) AS n_other_countries
   FROM main.countries
 )
 SELECT

--- a/tests/test_sql_refsols/technograph_country_cartesian_oddball_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_country_cartesian_oddball_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS n_other_countries
+    COUNT(*) AS n_other_countries
   FROM main.countries
 )
 SELECT

--- a/tests/test_sql_refsols/technograph_country_combination_analysis_ansi.sql
+++ b/tests/test_sql_refsols/technograph_country_combination_analysis_ansi.sql
@@ -1,13 +1,13 @@
 WITH _s7 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
     in_device_id
 ), _s9 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     SUM(_s7.agg_2) AS agg_4,
     countries.co_id AS _id,
     countries_2.co_id AS _id_3

--- a/tests/test_sql_refsols/technograph_country_combination_analysis_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_country_combination_analysis_sqlite.sql
@@ -1,13 +1,13 @@
 WITH _s7 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
     in_device_id
 ), _s9 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     SUM(_s7.agg_2) AS agg_4,
     countries.co_id AS _id,
     countries_2.co_id AS _id_3

--- a/tests/test_sql_refsols/technograph_country_incident_rate_analysis_ansi.sql
+++ b/tests/test_sql_refsols/technograph_country_incident_rate_analysis_ansi.sql
@@ -4,14 +4,14 @@ WITH _t3 AS (
   FROM main.incidents
 ), _s1 AS (
   SELECT
-    COUNT() AS agg_9,
+    COUNT(*) AS agg_9,
     device_id
   FROM _t3
   GROUP BY
     device_id
 ), _s3 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     SUM(_s1.agg_9) AS agg_11,
     devices.de_production_country_id AS factory_country_id
   FROM main.devices AS devices
@@ -21,7 +21,7 @@ WITH _t3 AS (
     devices.de_production_country_id
 ), _s5 AS (
   SELECT
-    COUNT() AS agg_12,
+    COUNT(*) AS agg_12,
     device_id
   FROM _t3
   GROUP BY
@@ -29,7 +29,7 @@ WITH _t3 AS (
 ), _s7 AS (
   SELECT
     SUM(_s5.agg_12) AS agg_14,
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     devices.de_purchase_country_id AS store_country_id
   FROM main.devices AS devices
   LEFT JOIN _s5 AS _s5
@@ -38,14 +38,14 @@ WITH _t3 AS (
     devices.de_purchase_country_id
 ), _s11 AS (
   SELECT
-    COUNT() AS agg_6,
+    COUNT(*) AS agg_6,
     device_id
   FROM _t3
   GROUP BY
     device_id
 ), _s13 AS (
   SELECT
-    COUNT() AS agg_5,
+    COUNT(*) AS agg_5,
     SUM(_s11.agg_6) AS agg_8,
     users.us_country_id AS country_id
   FROM main.users AS users

--- a/tests/test_sql_refsols/technograph_country_incident_rate_analysis_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_country_incident_rate_analysis_sqlite.sql
@@ -4,14 +4,14 @@ WITH _t3 AS (
   FROM main.incidents
 ), _s1 AS (
   SELECT
-    COUNT() AS agg_9,
+    COUNT(*) AS agg_9,
     device_id
   FROM _t3
   GROUP BY
     device_id
 ), _s3 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     SUM(_s1.agg_9) AS agg_11,
     devices.de_production_country_id AS factory_country_id
   FROM main.devices AS devices
@@ -21,7 +21,7 @@ WITH _t3 AS (
     devices.de_production_country_id
 ), _s5 AS (
   SELECT
-    COUNT() AS agg_12,
+    COUNT(*) AS agg_12,
     device_id
   FROM _t3
   GROUP BY
@@ -29,7 +29,7 @@ WITH _t3 AS (
 ), _s7 AS (
   SELECT
     SUM(_s5.agg_12) AS agg_14,
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     devices.de_purchase_country_id AS store_country_id
   FROM main.devices AS devices
   LEFT JOIN _s5 AS _s5
@@ -38,14 +38,14 @@ WITH _t3 AS (
     devices.de_purchase_country_id
 ), _s11 AS (
   SELECT
-    COUNT() AS agg_6,
+    COUNT(*) AS agg_6,
     device_id
   FROM _t3
   GROUP BY
     device_id
 ), _s13 AS (
   SELECT
-    COUNT() AS agg_5,
+    COUNT(*) AS agg_5,
     SUM(_s11.agg_6) AS agg_8,
     users.us_country_id AS country_id
   FROM main.users AS users

--- a/tests/test_sql_refsols/technograph_error_percentages_sun_set_by_error_ansi.sql
+++ b/tests/test_sql_refsols/technograph_error_percentages_sun_set_by_error_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s5 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     incidents.in_error_id AS error_id
   FROM main.incidents AS incidents
   JOIN main.devices AS devices

--- a/tests/test_sql_refsols/technograph_error_percentages_sun_set_by_error_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_error_percentages_sun_set_by_error_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s5 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     incidents.in_error_id AS error_id
   FROM main.incidents AS incidents
   JOIN main.devices AS devices

--- a/tests/test_sql_refsols/technograph_error_rate_sun_set_by_factory_country_ansi.sql
+++ b/tests/test_sql_refsols/technograph_error_rate_sun_set_by_factory_country_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
@@ -8,7 +8,7 @@ WITH _s3 AS (
 ), _s5 AS (
   SELECT
     SUM(COALESCE(_s3.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     devices.de_production_country_id AS factory_country_id
   FROM main.devices AS devices
   JOIN main.products AS products

--- a/tests/test_sql_refsols/technograph_error_rate_sun_set_by_factory_country_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_error_rate_sun_set_by_factory_country_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
@@ -8,7 +8,7 @@ WITH _s3 AS (
 ), _s5 AS (
   SELECT
     SUM(COALESCE(_s3.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     devices.de_production_country_id AS factory_country_id
   FROM main.devices AS devices
   JOIN main.products AS products

--- a/tests/test_sql_refsols/technograph_global_incident_rate_ansi.sql
+++ b/tests/test_sql_refsols/technograph_global_incident_rate_ansi.sql
@@ -1,10 +1,10 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0
+    COUNT(*) AS agg_0
   FROM main.incidents
 ), _s1 AS (
   SELECT
-    COUNT() AS agg_1
+    COUNT(*) AS agg_1
   FROM main.devices
 )
 SELECT

--- a/tests/test_sql_refsols/technograph_global_incident_rate_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_global_incident_rate_sqlite.sql
@@ -1,10 +1,10 @@
 WITH _s0 AS (
   SELECT
-    COUNT() AS agg_0
+    COUNT(*) AS agg_0
   FROM main.incidents
 ), _s1 AS (
   SELECT
-    COUNT() AS agg_1
+    COUNT(*) AS agg_1
   FROM main.devices
 )
 SELECT

--- a/tests/test_sql_refsols/technograph_hot_purchase_window_ansi.sql
+++ b/tests/test_sql_refsols/technograph_hot_purchase_window_ansi.sql
@@ -4,7 +4,7 @@ WITH _t3 AS (
   FROM main.calendar
 ), _t0 AS (
   SELECT
-    COUNT() AS n_purchases,
+    COUNT(*) AS n_purchases,
     ANY_VALUE(_t3.calendar_day) AS start_of_period
   FROM _t3 AS _t3
   CROSS JOIN _t3 AS _s1

--- a/tests/test_sql_refsols/technograph_hot_purchase_window_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_hot_purchase_window_sqlite.sql
@@ -4,7 +4,7 @@ WITH _t3 AS (
   FROM main.calendar
 ), _t0 AS (
   SELECT
-    COUNT() AS n_purchases,
+    COUNT(*) AS n_purchases,
     MAX(_t3.calendar_day) AS start_of_period
   FROM _t3 AS _t3
   CROSS JOIN _t3 AS _s1

--- a/tests/test_sql_refsols/technograph_incident_rate_by_release_year_ansi.sql
+++ b/tests/test_sql_refsols/technograph_incident_rate_by_release_year_ansi.sql
@@ -5,7 +5,7 @@ WITH _t3 AS (
   FROM main.products
 ), _s6 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     EXTRACT(YEAR FROM _t3.release_date) AS release_year
   FROM main.devices AS devices
   JOIN _t3 AS _t3
@@ -14,7 +14,7 @@ WITH _t3 AS (
     EXTRACT(YEAR FROM _t3.release_date)
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     EXTRACT(YEAR FROM _t5.release_date) AS release_year
   FROM main.devices AS devices
   JOIN _t3 AS _t5

--- a/tests/test_sql_refsols/technograph_incident_rate_by_release_year_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_incident_rate_by_release_year_sqlite.sql
@@ -5,7 +5,7 @@ WITH _t3 AS (
   FROM main.products
 ), _s6 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     CAST(STRFTIME('%Y', _t3.release_date) AS INTEGER) AS release_year
   FROM main.devices AS devices
   JOIN _t3 AS _t3
@@ -14,7 +14,7 @@ WITH _t3 AS (
     CAST(STRFTIME('%Y', _t3.release_date) AS INTEGER)
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     CAST(STRFTIME('%Y', _t5.release_date) AS INTEGER) AS release_year
   FROM main.devices AS devices
   JOIN _t3 AS _t5

--- a/tests/test_sql_refsols/technograph_incident_rate_per_brand_ansi.sql
+++ b/tests/test_sql_refsols/technograph_incident_rate_per_brand_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
@@ -8,7 +8,7 @@ WITH _s3 AS (
 ), _t0 AS (
   SELECT
     SUM(COALESCE(_s3.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     products.pr_brand AS brand
   FROM main.devices AS devices
   JOIN main.products AS products

--- a/tests/test_sql_refsols/technograph_incident_rate_per_brand_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_incident_rate_per_brand_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
@@ -8,7 +8,7 @@ WITH _s3 AS (
 ), _t0 AS (
   SELECT
     SUM(COALESCE(_s3.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     products.pr_brand AS brand
   FROM main.devices AS devices
   JOIN main.products AS products

--- a/tests/test_sql_refsols/technograph_monthly_incident_rate_ansi.sql
+++ b/tests/test_sql_refsols/technograph_monthly_incident_rate_ansi.sql
@@ -9,7 +9,7 @@ WITH _t4 AS (
   FROM main.countries
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     _t7.calendar_day
   FROM _t4 AS _t7
   JOIN main.calendar AS calendar
@@ -24,7 +24,7 @@ WITH _t4 AS (
     _t7.calendar_day
 ), _s15 AS (
   SELECT
-    COUNT() AS agg_5,
+    COUNT(*) AS agg_5,
     _t11.calendar_day
   FROM _t4 AS _t11
   JOIN main.incidents AS incidents

--- a/tests/test_sql_refsols/technograph_monthly_incident_rate_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_monthly_incident_rate_sqlite.sql
@@ -9,7 +9,7 @@ WITH _t4 AS (
   FROM main.countries
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     _t7.calendar_day
   FROM _t4 AS _t7
   JOIN main.calendar AS calendar
@@ -24,7 +24,7 @@ WITH _t4 AS (
     _t7.calendar_day
 ), _s15 AS (
   SELECT
-    COUNT() AS agg_5,
+    COUNT(*) AS agg_5,
     _t11.calendar_day
   FROM _t4 AS _t11
   JOIN main.incidents AS incidents

--- a/tests/test_sql_refsols/technograph_most_unreliable_products_ansi.sql
+++ b/tests/test_sql_refsols/technograph_most_unreliable_products_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
@@ -8,7 +8,7 @@ WITH _s1 AS (
 ), _t0 AS (
   SELECT
     SUM(COALESCE(_s1.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     devices.de_product_id AS product_id
   FROM main.devices AS devices
   LEFT JOIN _s1 AS _s1

--- a/tests/test_sql_refsols/technograph_most_unreliable_products_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_most_unreliable_products_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     in_device_id AS device_id
   FROM main.incidents
   GROUP BY
@@ -8,7 +8,7 @@ WITH _s1 AS (
 ), _t0 AS (
   SELECT
     SUM(COALESCE(_s1.agg_0, 0)) AS agg_0,
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     devices.de_product_id AS product_id
   FROM main.devices AS devices
   LEFT JOIN _s1 AS _s1

--- a/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_goldcopperstar_ansi.sql
+++ b/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_goldcopperstar_ansi.sql
@@ -15,7 +15,7 @@ WITH _s14 AS (
   FROM main.products
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     _s0.calendar_day
   FROM _t6 AS _s0
   JOIN main.incidents AS incidents
@@ -28,7 +28,7 @@ WITH _s14 AS (
     _s0.calendar_day
 ), _s13 AS (
   SELECT
-    COUNT() AS agg_6,
+    COUNT(*) AS agg_6,
     _s8.calendar_day
   FROM _t6 AS _s8
   JOIN main.devices AS devices

--- a/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_goldcopperstar_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_goldcopperstar_sqlite.sql
@@ -15,7 +15,7 @@ WITH _s14 AS (
   FROM main.products
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     _s0.calendar_day
   FROM _t6 AS _s0
   JOIN main.incidents AS incidents
@@ -28,7 +28,7 @@ WITH _s14 AS (
     _s0.calendar_day
 ), _s13 AS (
   SELECT
-    COUNT() AS agg_6,
+    COUNT(*) AS agg_6,
     _s8.calendar_day
   FROM _t6 AS _s8
   JOIN main.devices AS devices

--- a/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_overall_ansi.sql
+++ b/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_overall_ansi.sql
@@ -4,7 +4,7 @@ WITH _t5 AS (
   FROM main.calendar
 ), _s3 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     _s0.calendar_day
   FROM _t5 AS _s0
   JOIN main.devices AS devices
@@ -13,7 +13,7 @@ WITH _t5 AS (
     _s0.calendar_day
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_5,
+    COUNT(*) AS agg_5,
     _s4.calendar_day
   FROM _t5 AS _s4
   JOIN main.incidents AS incidents

--- a/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_overall_sqlite.sql
+++ b/tests/test_sql_refsols/technograph_year_cumulative_incident_rate_overall_sqlite.sql
@@ -4,7 +4,7 @@ WITH _t5 AS (
   FROM main.calendar
 ), _s3 AS (
   SELECT
-    COUNT() AS agg_2,
+    COUNT(*) AS agg_2,
     _s0.calendar_day
   FROM _t5 AS _s0
   JOIN main.devices AS devices
@@ -13,7 +13,7 @@ WITH _t5 AS (
     _s0.calendar_day
 ), _s7 AS (
   SELECT
-    COUNT() AS agg_5,
+    COUNT(*) AS agg_5,
     _s4.calendar_day
   FROM _t5 AS _s4
   JOIN main.incidents AS incidents

--- a/tests/test_sql_refsols/tpch_q13_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q13_ansi.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     o_custkey AS customer_key
   FROM tpch.orders
   WHERE
@@ -9,7 +9,7 @@ WITH _s1 AS (
     o_custkey
 ), _t0 AS (
   SELECT
-    COUNT() AS custdist,
+    COUNT(*) AS custdist,
     COALESCE(_s1.agg_0, 0) AS c_count
   FROM tpch.customer AS customer
   LEFT JOIN _s1 AS _s1

--- a/tests/test_sql_refsols/tpch_q13_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q13_sqlite.sql
@@ -1,6 +1,6 @@
 WITH _s1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     o_custkey AS customer_key
   FROM tpch.orders
   WHERE
@@ -9,7 +9,7 @@ WITH _s1 AS (
     o_custkey
 ), _t0 AS (
   SELECT
-    COUNT() AS custdist,
+    COUNT(*) AS custdist,
     COALESCE(_s1.agg_0, 0) AS c_count
   FROM tpch.customer AS customer
   LEFT JOIN _s1 AS _s1

--- a/tests/test_sql_refsols/tpch_q1_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q1_ansi.sql
@@ -3,7 +3,7 @@ WITH _t1 AS (
     AVG(l_discount) AS agg_0,
     AVG(l_extendedprice) AS agg_1,
     AVG(l_quantity) AS agg_2,
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     SUM(l_extendedprice) AS agg_4,
     SUM(l_extendedprice * (
       1 - l_discount

--- a/tests/test_sql_refsols/tpch_q1_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q1_sqlite.sql
@@ -3,7 +3,7 @@ WITH _t1 AS (
     AVG(l_discount) AS agg_0,
     AVG(l_extendedprice) AS agg_1,
     AVG(l_quantity) AS agg_2,
-    COUNT() AS agg_3,
+    COUNT(*) AS agg_3,
     SUM(l_extendedprice) AS agg_4,
     SUM(l_extendedprice * (
       1 - l_discount

--- a/tests/test_sql_refsols/tpch_q20_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q20_ansi.sql
@@ -9,7 +9,7 @@ WITH _t5 AS (
     l_partkey
 ), _t1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     partsupp.ps_suppkey AS supplier_key
   FROM tpch.partsupp AS partsupp
   JOIN tpch.part AS part

--- a/tests/test_sql_refsols/tpch_q20_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q20_sqlite.sql
@@ -9,7 +9,7 @@ WITH _t5 AS (
     l_partkey
 ), _t1 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     partsupp.ps_suppkey AS supplier_key
   FROM tpch.partsupp AS partsupp
   JOIN tpch.part AS part

--- a/tests/test_sql_refsols/tpch_q21_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q21_ansi.sql
@@ -101,7 +101,7 @@ WITH _s0 AS (
     )
 ), _s9 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     _t3.supplier_key AS supplier_key
   FROM _t3 AS _t3
   GROUP BY

--- a/tests/test_sql_refsols/tpch_q21_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q21_sqlite.sql
@@ -101,7 +101,7 @@ WITH _s0 AS (
     )
 ), _s9 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     _t3.supplier_key AS supplier_key
   FROM _t3 AS _t3
   GROUP BY

--- a/tests/test_sql_refsols/tpch_q22_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q22_ansi.sql
@@ -7,14 +7,14 @@ WITH _s0 AS (
     AND c_acctbal > 0.0
 ), _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     o_custkey AS customer_key
   FROM tpch.orders
   GROUP BY
     o_custkey
 ), _t1 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     SUM(customer.c_acctbal) AS agg_2,
     SUBSTRING(customer.c_phone, 1, 2) AS cntry_code
   FROM _s0 AS _s0

--- a/tests/test_sql_refsols/tpch_q22_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q22_sqlite.sql
@@ -7,14 +7,14 @@ WITH _s0 AS (
     AND c_acctbal > 0.0
 ), _s3 AS (
   SELECT
-    COUNT() AS agg_0,
+    COUNT(*) AS agg_0,
     o_custkey AS customer_key
   FROM tpch.orders
   GROUP BY
     o_custkey
 ), _t1 AS (
   SELECT
-    COUNT() AS agg_1,
+    COUNT(*) AS agg_1,
     SUM(customer.c_acctbal) AS agg_2,
     SUBSTRING(customer.c_phone, 1, 2) AS cntry_code
   FROM _s0 AS _s0

--- a/tests/test_sql_refsols/tpch_q4_ansi.sql
+++ b/tests/test_sql_refsols/tpch_q4_ansi.sql
@@ -38,7 +38,7 @@ WITH _t2 AS (
     )
 ), _t0 AS (
   SELECT
-    COUNT() AS order_count,
+    COUNT(*) AS order_count,
     _t1.order_priority AS o_orderpriority
   FROM _t1 AS _t1
   GROUP BY

--- a/tests/test_sql_refsols/tpch_q4_sqlite.sql
+++ b/tests/test_sql_refsols/tpch_q4_sqlite.sql
@@ -51,7 +51,7 @@ WITH _t2 AS (
     )
 ), _t0 AS (
   SELECT
-    COUNT() AS order_count,
+    COUNT(*) AS order_count,
     _t1.order_priority AS o_orderpriority
   FROM _t1 AS _t1
   GROUP BY


### PR DESCRIPTION
Generate SQL with `COUNT(*)` instead of `COUNT()` as `COUNT()` is not standard SQL. Writing `COUNT()` with no argument leads to a syntax error in most SQL databases