### PR TITLE
Fixing bug with test broker_gen2

### DIFF
--- a/tests/test_pydough_functions/defog_test_functions.py
+++ b/tests/test_pydough_functions/defog_test_functions.py
@@ -579,7 +579,9 @@ def impl_defog_broker_gen2():
     Return the number of transactions by users who joined in the past 70
     days.
     """
-    selected_tx = transactions.WHERE(customer.join_date >= DATETIME("now", "-70 days"))
+    selected_tx = transactions.WHERE(
+        customer.join_date >= DATETIME("now", "-70 days", "start of day")
+    )
 
     return Broker.CALCULATE(transaction_count=COUNT(selected_tx.customer_id))
 

--- a/tests/test_sql_refsols/defog_broker_gen2_ansi.sql
+++ b/tests/test_sql_refsols/defog_broker_gen2_ansi.sql
@@ -3,4 +3,4 @@ SELECT
 FROM main.sbtransaction AS sbtransaction
 JOIN main.sbcustomer AS sbcustomer
   ON sbcustomer.sbcustid = sbtransaction.sbtxcustid
-  AND sbcustomer.sbcustjoindate >= DATE_ADD(CURRENT_TIMESTAMP(), -70, 'DAY')
+  AND sbcustomer.sbcustjoindate >= DATE_TRUNC('DAY', DATE_ADD(CURRENT_TIMESTAMP(), -70, 'DAY'))

--- a/tests/test_sql_refsols/defog_broker_gen2_sqlite.sql
+++ b/tests/test_sql_refsols/defog_broker_gen2_sqlite.sql
@@ -3,4 +3,4 @@ SELECT
 FROM main.sbtransaction AS sbtransaction
 JOIN main.sbcustomer AS sbcustomer
   ON sbcustomer.sbcustid = sbtransaction.sbtxcustid
-  AND sbcustomer.sbcustjoindate >= DATETIME('now', '-70 day')
+  AND sbcustomer.sbcustjoindate >= DATE(DATETIME('now', '-70 day'), 'start of day')


### PR DESCRIPTION
The actual defog SQL text is as follows:
```sql
SELECT COUNT(t.sbTxCustId) AS transaction_count
FROM sbTransaction AS t
JOIN sbCustomer AS c ON t.sbTxCustId = c.sbCustId
WHERE c.sbCustJoinDate >= date('now', '-70 days')
```
But the current PyDough implemnetation uses `DATETIME("now", "-70 days")` which does not truncate to the start of the day. To fix this, changed it to `DATETIME("now", "-70 days", "start of day")` so it is the same as the refsol.