### PR TITLE
Add PyDough metadata for masked table columns

### DIFF
--- a/pydough/metadata/__init__.py
+++ b/pydough/metadata/__init__.py
@@ -7,6 +7,7 @@ __all__ = [
     "CollectionMetadata",
     "GeneralJoinMetadata",
     "GraphMetadata",
+    "MaskedTableColumnMetadata",
     "PropertyMetadata",
     "PyDoughMetadataException",
     "SimpleJoinMetadata",
@@ -23,6 +24,7 @@ from .parse import parse_json_metadata_from_file
 from .properties import (
     CartesianProductMetadata,
     GeneralJoinMetadata,
+    MaskedTableColumnMetadata,
     PropertyMetadata,
     SimpleJoinMetadata,
     SubcollectionRelationshipMetadata,

--- a/pydough/metadata/collections/collection_metadata.py
+++ b/pydough/metadata/collections/collection_metadata.py
@@ -213,36 +213,6 @@ class CollectionMetadata(AbstractMetadata):
     def __getitem__(self, key: str):
         return self.get_property(key)
 
-    @staticmethod
-    def get_class_for_collection_type(
-        name: str, error_name: str
-    ) -> type["CollectionMetadata"]:
-        """
-        Fetches the PropertyType implementation class for a string
-        representation of the collection type.
-
-        Args:
-            `name`: the string representation of a collection type.
-            `error_name`: the string used in error messages to describe
-            the object that `name` came from.
-
-        Returns:
-            The class of the property type corresponding to `name`.
-
-        Raises:
-            `PyDoughMetadataException` if the string does not correspond
-            to a known class type.
-        """
-        from .simple_table_metadata import SimpleTableMetadata
-
-        match name:
-            case "simple_table":
-                return SimpleTableMetadata
-            case property_type:
-                raise PyDoughMetadataException(
-                    f"Unrecognized collection type for {error_name}: {repr(property_type)}"
-                )
-
     def add_properties_from_json(self, properties_json: list) -> None:
         """
         Insert the scalar properties from the JSON for collection into the
@@ -253,7 +223,7 @@ class CollectionMetadata(AbstractMetadata):
             scalar property that should be parsed and inserted into the
             collection.
         """
-        from pydough.metadata.properties import TableColumnMetadata
+        from pydough.metadata import MaskedTableColumnMetadata, TableColumnMetadata
 
         for property_json in properties_json:
             # Extract the name/type, and create the string used to identify
@@ -267,6 +237,10 @@ class CollectionMetadata(AbstractMetadata):
             match property_type:
                 case "table column":
                     TableColumnMetadata.parse_from_json(
+                        self, property_name, property_json
+                    )
+                case "masked table column":
+                    MaskedTableColumnMetadata.parse_from_json(
                         self, property_name, property_json
                     )
                 case _:

--- a/pydough/metadata/properties/__init__.py
+++ b/pydough/metadata/properties/__init__.py
@@ -5,6 +5,7 @@ Submodule of the PyDough metadata module defining metadata for properties.
 __all__ = [
     "CartesianProductMetadata",
     "GeneralJoinMetadata",
+    "MaskedTableColumnMetadata",
     "PropertyMetadata",
     "ReversiblePropertyMetadata",
     "ScalarAttributeMetadata",
@@ -15,6 +16,7 @@ __all__ = [
 
 from .cartesian_product_metadata import CartesianProductMetadata
 from .general_join_metadata import GeneralJoinMetadata
+from .masked_table_column_metadata import MaskedTableColumnMetadata
 from .property_metadata import PropertyMetadata
 from .reversible_property_metadata import ReversiblePropertyMetadata
 from .scalar_attribute_metadata import ScalarAttributeMetadata

--- a/pydough/metadata/properties/masked_table_column_metadata.py
+++ b/pydough/metadata/properties/masked_table_column_metadata.py
@@ -1,0 +1,194 @@
+"""
+Definition of the class for PyDough metadata for properties that access a
+column of a table from a relational system that has been masked by a certain
+protocol, but has an un-masking protocol as well.
+"""
+
+__all__ = ["MaskedTableColumnMetadata"]
+
+
+from pydough.metadata.collections import CollectionMetadata
+from pydough.metadata.errors import (
+    NoExtraKeys,
+    PyDoughMetadataException,
+    extract_array,
+    extract_bool,
+    extract_object,
+    extract_string,
+)
+from pydough.types import PyDoughType, parse_type_from_string
+from pydough.types.errors import PyDoughTypeException
+
+from .table_column_metadata import TableColumnMetadata
+
+
+class MaskedTableColumnMetadata(TableColumnMetadata):
+    """
+    Concrete metadata implementation for a PyDough property representing a
+    column of data from a relational table that has been masked by a certain
+    protocol, but has an un-masking protocol as well.
+    """
+
+    # Set of names of fields that can be included in the JSON object
+    # describing a table column property.
+    allowed_fields: set[str] = TableColumnMetadata.allowed_fields | {
+        "protect protocol",
+        "unprotect protocol",
+        "server masked",
+    }
+
+    def __init__(
+        self,
+        name: str,
+        collection: CollectionMetadata,
+        data_type: PyDoughType,
+        column_name: str,
+        unprotect_protocol: str,
+        protect_protocol: str,
+        server_masked: bool,
+        sample_values: list | None = None,
+        description: str | None = None,
+        synonyms: list[str] | None = None,
+        extra_semantic_info: dict | None = None,
+    ):
+        super().__init__(
+            name,
+            collection,
+            data_type,
+            column_name,
+            sample_values,
+            description,
+            synonyms,
+            extra_semantic_info,
+        )
+        self._unprotect_protocol: str = unprotect_protocol
+        self._protect_protocol: str = protect_protocol
+        self._server_masked: bool = server_masked
+
+    @property
+    def unprotect_protocol(self) -> str:
+        """
+        Returns the format string used to un-mask the data in this
+        table column property. The format string should create SQL text such
+        that when `self.unprotect_protocol.format(value)` is called, where
+        `value` is the SQL text string corresponding to a value that is masked,
+        it returns the SQL text string that will un-mask the value.
+        """
+        return self._unprotect_protocol
+
+    @property
+    def protect_protocol(self) -> str:
+        """
+        Returns the format string used to mask the data in this table column
+        property. The format string should create SQL text such that when
+        `self.protect_protocol.format(value)` is called, where `value` is the
+        SQL text string corresponding to a value that is to be masked, it
+        returns the SQL text string that will mask the value in a way that can
+        be reversed by `self.unprotect_protocol`.
+        """
+        return self._protect_protocol
+
+    @property
+    def server_masked(self) -> bool:
+        """
+        Returns whether the data in this table column property is masked in
+        a manner that corresponds to a server that can be sent predicate queries
+        in order to infer smarter predicates that do not require un-masking the
+        data.
+        """
+        return self._server_masked
+
+    @property
+    def column_name(self) -> str:
+        return self._column_name
+
+    @staticmethod
+    def create_error_name(name: str, collection_error_name: str):
+        return f"masked table column property {name!r} of {collection_error_name}"
+
+    @property
+    def components(self) -> list:
+        comp: list = super().components
+        comp.append(self.column_name)
+        comp.append(self.unprotect_protocol)
+        comp.append(self.protect_protocol)
+        comp.append(self.server_masked)
+        return comp
+
+    @staticmethod
+    def parse_from_json(
+        collection: CollectionMetadata, property_name: str, property_json: dict
+    ) -> None:
+        """
+        Procedure dispatched from PropertyMetadata.parse_from_json to handle
+        the parsing for table column properties.
+
+        Args:
+            `collection`: the metadata for the PyDough collection that the
+            property would be inserted into.
+            `property_name`: the name of the property that would be inserted.
+            `property_json`: the JSON object that would be parsed to create
+            the new table column property.
+
+        Raises:
+            `PyDoughMetadataException`: if the JSON for the property is
+            malformed.
+        """
+        error_name: str = MaskedTableColumnMetadata.create_error_name(
+            property_name, collection.error_name
+        )
+        # Extract the `data_type` and `column_name` fields from the JSON object
+        type_string: str = extract_string(property_json, "data type", error_name)
+        try:
+            data_type: PyDoughType = parse_type_from_string(type_string)
+        except PyDoughTypeException as e:
+            raise PyDoughMetadataException(*e.args)
+        column_name: str = extract_string(property_json, "column name", error_name)
+
+        # Extract the `unprotect protocol`, `protect protocol`, and
+        # `server masked` fields from the JSON object.
+        unprotect_protocol: str = extract_string(
+            property_json, "unprotect protocol", error_name
+        )
+        protect_protocol: str = extract_string(
+            property_json, "protect protocol", error_name
+        )
+        server_masked: bool = False
+        if "server masked" in property_json:
+            server_masked = extract_bool(property_json, "server masked", error_name)
+
+        NoExtraKeys(MaskedTableColumnMetadata.allowed_fields).verify(
+            property_json, error_name
+        )
+
+        # Extract the optional fields from the JSON object.
+        sample_values: list | None = None
+        description: str | None = None
+        synonyms: list[str] | None = None
+        extra_semantic_info: dict | None = None
+        if "sample values" in property_json:
+            sample_values = extract_array(property_json, "sample values", error_name)
+        if "description" in property_json:
+            description = extract_string(property_json, "description", error_name)
+        if "synonyms" in property_json:
+            synonyms = extract_array(property_json, "synonyms", error_name)
+        if "extra semantic info" in property_json:
+            extra_semantic_info = extract_object(
+                property_json, "extra semantic info", error_name
+            )
+
+        # Build the new property metadata object and add it to the collection.
+        property: MaskedTableColumnMetadata = MaskedTableColumnMetadata(
+            property_name,
+            collection,
+            data_type,
+            column_name,
+            unprotect_protocol,
+            protect_protocol,
+            server_masked,
+            sample_values,
+            description,
+            synonyms,
+            extra_semantic_info,
+        )
+        collection.add_property(property)

--- a/tests/test_metadata/invalid_graphs.json
+++ b/tests/test_metadata/invalid_graphs.json
@@ -2840,6 +2840,253 @@
       ]
     },
     {
+      "name": "MASKED_TABLE_COLUMN_MISSING_COLUMN_NAME",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "data type": "string",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": "LOWER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_BAD_COLUMN_NAME",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": true,
+              "data type": "string",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": "LOWER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_MISSING_DATA_TYPE",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": "LOWER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_BAD_DATA_TYPE",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "strdatmeric",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": "LOWER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_MISSING_UNPROTECT_PROTOCOL",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "string",
+              "protect protocol": "LOWER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_BAD_UNPROTECT_PROTOCOL",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "string",
+              "unprotect protocol": [0, 1, 2],
+              "protect protocol": "LOWER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_MISSING_PROTECT_PROTOCOL",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "string",
+              "unprotect protocol": "UPPER({})",
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_BAD_PROTECT_PROTOCOL",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "string",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": 1,
+              "server masked": false
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_BAD_SERVER_MASKED",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "key", "type": "table column", "column name": "c_key", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "string",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": "LOWER({})",
+              "server masked": "not a boolean"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MASKED_TABLE_COLUMN_EXTRA_FIELDS",
+      "version": "V2",
+      "relationships": [],
+      "collections": [
+        {
+          "name": "customers",
+          "type": "simple table",
+          "table path": "CUSTOMERS",
+          "unique properties": ["key"],
+          "properties": [
+            {"name": "c_key", "type": "table column", "column name": "customer_id", "data type": "numeric"},
+            {
+              "name": "name",
+              "type": "masked table column",
+              "column name": "c_name",
+              "data type": "string",
+              "unprotect protocol": "UPPER({})",
+              "protect protocol": "LOWER({})",
+              "server masked": false,
+              "foo": "bar"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "BAD_JOIN_CONDITIONS",
       "version": "V2",
       "collections": [

--- a/tests/test_metadata_errors.py
+++ b/tests/test_metadata_errors.py
@@ -732,6 +732,58 @@ def test_missing_property(get_sample_graph: graph_fetcher) -> None:
             ),
             id="BAD_FUNCTION_SELECT_ARGUMENT_DEDUCER_EXTRA_FIELD",
         ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_MISSING_COLUMN_NAME",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_MISSING_COLUMN_NAME' must be a JSON object containing a field 'column name' and field 'column name' must be a string",
+            id="MASKED_TABLE_COLUMN_MISSING_COLUMN_NAME",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_BAD_COLUMN_NAME",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_BAD_COLUMN_NAME' must be a JSON object containing a field 'column name' and field 'column name' must be a string",
+            id="MASKED_TABLE_COLUMN_BAD_COLUMN_NAME",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_MISSING_DATA_TYPE",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_MISSING_DATA_TYPE' must be a JSON object containing a field 'data type' and field 'data type' must be a string",
+            id="MASKED_TABLE_COLUMN_MISSING_DATA_TYPE",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_BAD_DATA_TYPE",
+            "Unrecognized type string 'strdatmeric'",
+            id="MASKED_TABLE_COLUMN_BAD_DATA_TYPE",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_MISSING_UNPROTECT_PROTOCOL",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_MISSING_UNPROTECT_PROTOCOL' must be a JSON object containing a field 'unprotect protocol' and field 'unprotect protocol' must be a string",
+            id="MASKED_TABLE_COLUMN_MISSING_UNPROTECT_PROTOCOL",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_BAD_UNPROTECT_PROTOCOL",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_BAD_UNPROTECT_PROTOCOL' must be a JSON object containing a field 'unprotect protocol' and field 'unprotect protocol' must be a string",
+            id="MASKED_TABLE_COLUMN_BAD_UNPROTECT_PROTOCOL",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_MISSING_PROTECT_PROTOCOL",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_MISSING_PROTECT_PROTOCOL' must be a JSON object containing a field 'protect protocol' and field 'protect protocol' must be a string",
+            id="MASKED_TABLE_COLUMN_MISSING_PROTECT_PROTOCOL",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_BAD_PROTECT_PROTOCOL",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_BAD_PROTECT_PROTOCOL' must be a JSON object containing a field 'protect protocol' and field 'protect protocol' must be a string",
+            id="MASKED_TABLE_COLUMN_BAD_PROTECT_PROTOCOL",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_BAD_SERVER_MASKED",
+            "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_BAD_SERVER_MASKED' must be a JSON object containing a field 'server masked' and field 'server masked' must be a boolean",
+            id="MASKED_TABLE_COLUMN_BAD_SERVER_MASKED",
+        ),
+        pytest.param(
+            "MASKED_TABLE_COLUMN_EXTRA_FIELDS",
+            re.escape(
+                "masked table column property 'name' of simple table collection 'customers' in graph 'MASKED_TABLE_COLUMN_EXTRA_FIELDS' must be a JSON object containing no fields except for ['column name', 'data type', 'description', 'extra semantic info', 'name', 'protect protocol', 'sample values', 'server masked', 'synonyms', 'type', 'unprotect protocol']"
+            ),
+            id="MASKED_TABLE_COLUMN_EXTRA_FIELDS",
+        ),
     ],
 )
 def test_invalid_graphs(


### PR DESCRIPTION
Adds a new metadata type `masked table column`, a subclass of `table column` representing data that is stored in the underlying data in some kind of encrypted manner but where the metadata stores additional information such as how to decrypt the data. These new metadata column types have the following additional properties:
- `unprotect protocol`: a Python format string containing SQL text that, when the value is injected, indicates how to decrypt the data.
- `protect protocol`: a Python format string containing SQL text that, when a value is injected, indicates how to encrypt the value in the same manner as the column was encrypted, so the unprotect protocol will reverse it.
- `server masked`: optional boolean (default False) which, if True, indicates that information about the encryption/decryption scheme is available in a server that can be queried to rewrite/optimize predicates to avoid unmasking.

For example, suppose a string column `name` is "encrypted" by uppercasing it, and "decrypted" by lowercasing it, and does not have a server. This would be the following metadata:
```json
{
  "name": "name",
  "type": "masked table column",
  "column name": "c_name",
  "data type": "string",
  "unprotect protocol": "UPPER({})",
  "protect protocol": "LOWER({})",
  "server masked": false
}
```

So for instance, when reading the data from the table, instead of placing `c_name` in the SELECT clause we would place `LOWER(c_name)` in the SELECT clause so it is "decrypted" (since the data int he table was uppercase). Conversely, if we wish to do a filter on `name == "john smith"`, instead of doing `LOWER(c_name) == "john smith"` we could use the protect protocol to rewrite as `c_name == UPPER("john smith")`.