### PR TITLE
Jkx/fix test metadata for type reserved word

### DIFF
--- a/tests/test_metadata/sf_masked_examples.json
+++ b/tests/test_metadata/sf_masked_examples.json
@@ -116,7 +116,7 @@
             "synonyms": ["customer id", "customer key", "customer number"]
           },
           {
-            "name": "type",
+            "name": "_type",
             "type": "table column",
             "column name": "loantype",
             "data type": "string",


### PR DESCRIPTION
Fix the FSI graph in `sf_masked_examples.json` for the use of the reserved word `type` in a property name.