### PR TITLE
Add extra SQL keywords to metadata validation

### DIFF
--- a/pydough/errors/error_utils.py
+++ b/pydough/errors/error_utils.py
@@ -328,11 +328,14 @@ class ValidSQLName(PyDoughPredicate):
     SQL_RESERVED_KEYWORDS: set[str] = {
         # Query & DML
         "select", "from", "where", "group", "having", "distinct", "as", 
-        "join", "inner", "union", "intersect", "except",
+        "join", "inner", "union", "intersect", "except", "order",
+        "limit", "with", "range", "window", "pivot", "unpivot", "fetch",
+        "cross", "outer", "full", 
 
         # DDL & schema
         "create", "alter", "drop", "table", "view", "index", "sequence",
         "trigger", "schema", "database", "column", "constraint",
+        "partition"
 
         # DML
         "insert", "update", "delete", "into", "values", "set",

--- a/tests/test_metadata/invalid_graphs.json
+++ b/tests/test_metadata/invalid_graphs.json
@@ -248,7 +248,7 @@
       "relationships": []
     },
     {
-      "name": "TABLE_PATH_RESERVED_KEYWORD",
+      "name": "TABLE_PATH_RESERVED_KEYWORD1",
       "version": "V2",
       "collections": [
         {
@@ -261,6 +261,28 @@
               "name": "_id",
               "type": "table column",
               "column name": "column_name",
+              "data type": "string",
+              "description": "column description"
+            }
+          ]
+        }
+      ],
+      "relationships": []
+    },
+    {
+      "name": "TABLE_PATH_RESERVED_KEYWORD2",
+      "version": "V2",
+      "collections": [
+        {
+          "name": "order_qualified_SQL_name",
+          "type": "simple table",
+          "table path": "main.order",
+          "unique properties": ["order_id"],
+          "properties": [
+            {
+              "name": "order_id",
+              "type": "table column",
+              "column name": "order_id",
               "data type": "string",
               "description": "column description"
             }

--- a/tests/test_metadata_errors.py
+++ b/tests/test_metadata_errors.py
@@ -139,9 +139,14 @@ def test_missing_property(get_sample_graph: graph_fetcher) -> None:
             id="COLUMN_NAME_RESERVED_KEYWORD",
         ),
         pytest.param(
-            "TABLE_PATH_RESERVED_KEYWORD",
-            "simple table collection 'cast_reserved_sql_word' in graph 'TABLE_PATH_RESERVED_KEYWORD' must have a SQL name that is not a reserved word",
-            id="TABLE_PATH_RESERVED_KEYWORD",
+            "TABLE_PATH_RESERVED_KEYWORD1",
+            "simple table collection 'cast_reserved_sql_word' in graph 'TABLE_PATH_RESERVED_KEYWORD1' must have a SQL name that is not a reserved word",
+            id="TABLE_PATH_RESERVED_KEYWORD1",
+        ),
+        pytest.param(
+            "TABLE_PATH_RESERVED_KEYWORD2",
+            "simple table collection 'order_qualified_SQL_name' in graph 'TABLE_PATH_RESERVED_KEYWORD2' must have a SQL name that is not a reserved word",
+            id="TABLE_PATH_RESERVED_KEYWORD2",
         ),
         pytest.param(
             "COLUMN_NAME_INVALID_NAME_1",


### PR DESCRIPTION
Add extra SQL keywords to metadata validation:
```
"order",
"limit", 
"with", 
"range", 
"window", 
"pivot", 
"unpivot", 
"fetch", 
"cross", 
"outer", 
"full",
"partition"
```