### PR TITLE
Improving the Mask Server Connection for PyDough

### DIFF
--- a/pydough/mask_server/mask_server.py
+++ b/pydough/mask_server/mask_server.py
@@ -93,7 +93,9 @@ class MaskServerInfo:
     perform the evaluation.
     """
 
-    def __init__(self, base_url: str, token: str | None = None):
+    def __init__(
+        self, base_url: str, token: str | None = None, api_key: str | None = None
+    ):
         """
         Initialize the MaskServerInfo with the given server URL.
 
@@ -102,7 +104,7 @@ class MaskServerInfo:
             `token`: Optional authentication token for the server.
         """
         self.connection: ServerConnection = ServerConnection(
-            base_url=base_url, token=token
+            base_url=base_url, token=token, api_key=api_key
         )
 
     def get_server_response_case(self, server_case: str) -> MaskServerResponse:

--- a/tests/mock_server/api_mock_server.py
+++ b/tests/mock_server/api_mock_server.py
@@ -28,23 +28,28 @@ class RequestPayload(BaseModel):
     expression_format: dict[str, str] = {"name": "linear", "version": "0.2.0"}
 
 
-def verify_token(request: Request):
+def authentication(request: Request):
     auth_header = request.headers.get("Authorization", None)
+    api_key = request.headers.get("X-API-Key", None)
 
-    if auth_header and auth_header != "Bearer test-token-123":
+    if (auth_header and auth_header != "Bearer test-token-123") or (
+        api_key and api_key != "api-key-123"
+    ):
         raise HTTPException(status_code=401, detail="Unauthorized request")
 
     return True
 
 
 @app.get("/health")
-def health(request: Request, authorized: bool = Depends(verify_token)):
+def health(request: Request, authorized: bool = Depends(authentication)):
     return {"status": "ok"}
 
 
 @app.post("/v1/predicates/batch-evaluate")
 def batch_evaluate(
-    request: Request, payload: RequestPayload, authorized: bool = Depends(verify_token)
+    request: Request,
+    payload: RequestPayload,
+    authorized: bool = Depends(authentication),
 ):
     responses: list[dict] = []
     for item in payload.items:


### PR DESCRIPTION
This PR improves the Mask Server Connection for PyDough by:
- Adding the functionality that adds custom headers to the request
- Adding tests for api-keys and tokens
- Building a connection with api_key