### PR TITLE
Make dealership_adv8 Test For SQL Files Check Deterministic 

### DIFF
--- a/.github/workflows/bodosql_testing.yml
+++ b/.github/workflows/bodosql_testing.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         # uv requires an existing virtual environment to install packages.

--- a/.github/workflows/build_pip.yml
+++ b/.github/workflows/build_pip.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Build Wheels
         run: |

--- a/.github/workflows/mysql_testing.yml
+++ b/.github/workflows/mysql_testing.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         run: uv venv

--- a/.github/workflows/oracle_testing.yml
+++ b/.github/workflows/oracle_testing.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         run: uv venv

--- a/.github/workflows/postgres_testing.yml
+++ b/.github/workflows/postgres_testing.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         run: uv venv

--- a/.github/workflows/pr_testing.yml
+++ b/.github/workflows/pr_testing.yml
@@ -164,7 +164,7 @@ jobs:
         uses: astral-sh/setup-uv@v3
         with:
           # Install a specific version of uv.
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Download TPCH DB
         run: ./demos/setup_tpch.sh ./tpch.db

--- a/.github/workflows/s3_testing.yml
+++ b/.github/workflows/s3_testing.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         run: uv venv

--- a/.github/workflows/sf_masked_testing.yml
+++ b/.github/workflows/sf_masked_testing.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         # See note in sf_testing.yml about why we use `uv venv` here.

--- a/.github/workflows/sf_testing.yml
+++ b/.github/workflows/sf_testing.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.4.23"
+          version: "0.6.0"
 
       - name: Create virtual environment
         # uv requires an existing virtual environment to install packages.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = ["pytz", "sqlglot==26.7.0", "pandas>=2.0.0", "jupyterlab", "pyarr
 # TODO: Add homepage + documentation when docs are live.
 Repository = "https://github.com/bodo-ai/PyDough"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "pre-commit",
     "pytest",
     "ruff==0.6.7",

--- a/tests/test_pipeline_defog.py
+++ b/tests/test_pipeline_defog.py
@@ -3,7 +3,10 @@ Integration tests for the PyDough workflow on the defog.ai queries.
 """
 
 from collections.abc import Callable
+from contextlib import nullcontext
+from unittest.mock import patch
 
+import pandas as pd
 import pytest
 
 from pydough import init_pydough_context, to_sql
@@ -754,6 +757,10 @@ def test_graph_structure_defog(defog_graphs: graph_fetcher, graph_name: str) -> 
                 defog_sql_text_dealership_adv8,
                 "dealership_adv8",
                 order_sensitive=True,
+                # Pin today so the generated VALUES clause (6 month-start
+                # timestamps) stays deterministic. Reference files reflect
+                # the Oct 2025 – Mar 2026 window (today = 2026-04-01).
+                fixed_today=pd.Timestamp("2026-04-01"),
             ),
             id="dealership_adv8",
         ),
@@ -2032,7 +2039,14 @@ def test_defog_until_sql(
     graph: GraphMetadata = get_dialect_defog_graphs(
         empty_context_database.dialect, graph_name
     )
-    unqualified: UnqualifiedNode = init_pydough_context(graph)(unqualified_impl)()
+    fixed_today = defog_pipeline_test_data.fixed_today
+    ctx = (
+        patch.object(pd.Timestamp, "today", return_value=fixed_today)
+        if fixed_today is not None
+        else nullcontext()
+    )
+    with ctx:
+        unqualified: UnqualifiedNode = init_pydough_context(graph)(unqualified_impl)()
     sql_text: str = to_sql(
         unqualified,
         metadata=graph,

--- a/tests/testing_utilities.py
+++ b/tests/testing_utilities.py
@@ -1101,6 +1101,16 @@ class PyDoughSQLComparisonTest:
     same column names as in the reference solution.
     """
 
+    fixed_today: pd.Timestamp | None = None
+    """
+    If set, ``pd.Timestamp.today`` is patched to return this value during
+    SQL generation in ``test_defog_until_sql``. Use this for queries that
+    call ``pd.Timestamp.today()`` internally (e.g. to build a date-range
+    dataframe), so the generated SQL stays deterministic and the reference
+    ``.sql`` files never go stale. The execution test (``test_defog_e2e``)
+    is unaffected; it uses SQL-native ``DATE('now', ...)`` expressions.
+    """
+
     def run_e2e_test(
         self,
         fetcher: graph_fetcher,


### PR DESCRIPTION
- Fix flaky `dealership_adv8` SQL files test: `impl_defog_dealership_adv8` asks “what are the sales metrics for the last 6 months?” It computes those 6 month boundaries in Python using today’s date, then adds them as hardcoded timestamps into the generated SQL (e.g. `VALUES ('2025-10-01'), ('2025-11-01'), ...`). The SQL comparison test works by saving that generated SQL to a reference file and comparing future runs against it. Since the 6-month window shifts every month, the reference file goes stale on the 1st of every month and the SQL file test fails.

- Solution: Add a `fixed_today: pd.Timestamp | None` field to `PyDoughSQLComparisonTest`. When set, `pd.Timestamp.today` is patched during SQL generation so the output is deterministic. The reference files are pinned to the `Oct 2025–Mar 2026 window (today = 2026-04-01)`. Execution tests are unaffected, they use SQL-native date expressions `(DATE('now', ...))`.

AND


`Migrate [tool.uv] dev-dependencies` to `[dependency-groups] dev` in `pyproject.toml` to silence a uv deprecation warning.